### PR TITLE
Fix missing isValid property in ValidationStatus

### DIFF
--- a/app/dashboard/sites/[siteId]/planner/page.tsx
+++ b/app/dashboard/sites/[siteId]/planner/page.tsx
@@ -224,10 +224,12 @@ export default function ReverseSiloPlannerPage() {
         message: targetPageId === '' ? 'Target page required' : undefined
       }
     ],
-    blockReason: undefined
+    blockReason: undefined,
+    isValid: false
   }
 
-  const isValid = validationStatus.rules.every(r => r.passed)
+  validationStatus.isValid = validationStatus.rules.every(r => r.passed)
+  const isValid = validationStatus.isValid
 
   const handleAddEntity = () => {
     if (entityInput.trim() && !entities.includes(entityInput.trim())) {


### PR DESCRIPTION
Add isValid property to validationStatus object in planner page to match ValidationStatus type definition. The property is now dynamically calculated based on validation rules.