### PR TITLE
fix: conflict action buttons + structural warning behavior

### DIFF
--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -462,6 +462,41 @@ class ConflictsService {
     }
   }
 
+  async acknowledge(conflictId: number | string): Promise<void> {
+    const res = await fetchWithAuth(`/api/v1/conflicts/${conflictId}/acknowledge/`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.message || data.detail || 'Failed to acknowledge conflict');
+    }
+  }
+
+  async setPrimary(conflictId: number | string, winnerUrl: string): Promise<void> {
+    const res = await fetchWithAuth(`/api/v1/conflicts/${conflictId}/set-primary/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ winner_url: winnerUrl }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.message || data.detail || 'Failed to set primary page');
+    }
+  }
+
+  async resolveWithRedirect(conflictId: number | string, resolutionType = 'redirect'): Promise<void> {
+    const res = await fetchWithAuth(`/api/v1/conflicts/${conflictId}/resolve/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resolution_type: resolutionType }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.message || data.detail || 'Failed to resolve conflict');
+    }
+  }
+
   async differentiate(siteId: number | string, payload: {
     pages: Array<{ url: string; title?: string; page_type?: string }>;
     keyword: string;


### PR DESCRIPTION
Wires Generate Merge Plan, Rewrite as Spoke, and Redirect buttons to real API endpoints. Hides action buttons on structural_warning conflicts (0 impressions/clicks) per CLAUDE.md spec.

## Changes

### BUG 1 — Action buttons now work (SearchConsole.tsx + api.ts)

**Generate Merge Plan** now calls `POST /api/v1/ai/generate` with `{ action: "merge", conflict_id }` and opens ContentPreviewModal with the formatted plan.

**Rewrite as Spoke** now calls `POST /api/v1/ai/generate` with `{ action: "spoke_rewrite", conflict_id }` and opens ContentPreviewModal.

**301 Map** opens a confirmation dialog showing `from_url → to_url`, then calls `POST /api/v1/conflicts/{id}/resolve` with `{ resolution_type: "redirect" }` on confirm.

**Set Primary** calls `POST /api/v1/conflicts/{id}/set-primary` with the first (HUB TARGET) page URL as the winner.

**View Silo Plan** shows a toast (coming soon) — endpoint TBD.

All failures show graceful toast errors rather than silent stubs.

### BUG 2 — Structural warnings no longer show action bar (SearchConsole.tsx + GovernanceDashboard.tsx)

Structural warnings are detected by `conflict_subtype === 'structural_warning'` **OR** `totalClicks === 0 && totalImpressions === 0` (fallback for when subtype is not yet in API response).

When structural_warning:
- Full action bar (Set Primary, 301 Map, Generate Merge Plan, Rewrite as Spoke, View Silo Plan) is hidden
- Spec-required note shown: "No search traffic data yet. Monitor — if both pages start ranking, they may compete."
- Single Acknowledge button shown — calls `PATCH /api/v1/conflicts/{id}/acknowledge`
- Severity capped at MEDIUM (never displays HIGH or CRITICAL)

### api.ts
Added `acknowledge()`, `setPrimary()`, and `resolveWithRedirect()` methods to `ConflictsService`.