### PR TITLE
fix: Pages Analyze button — add missing Next.js proxy routes

### DIFF
--- a/app/api/v1/sites/[id]/pages/analysis/route.ts
+++ b/app/api/v1/sites/[id]/pages/analysis/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SITES_ENDPOINTS } from '@/lib/backend-api';
+
+function getAuthHeader(request: NextRequest): string | null {
+  return request.headers.get('authorization');
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = getAuthHeader(request);
+  if (!auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const pageUrl = searchParams.get('page_url');
+    const url = pageUrl
+      ? `${SITES_ENDPOINTS.pagesAnalysis(id)}?page_url=${encodeURIComponent(pageUrl)}`
+      : SITES_ENDPOINTS.pagesAnalysis(id);
+    const res = await fetch(url, {
+      headers: { Authorization: auth, Accept: 'application/json' },
+    });
+    if (res.status === 404) {
+      return NextResponse.json({ message: 'Not found' }, { status: 404 });
+    }
+    const data = await res.json();
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error('Pages analysis proxy error:', e);
+    return NextResponse.json(
+      { message: 'Unable to reach backend' },
+      { status: 502 }
+    );
+  }
+}

--- a/app/api/v1/sites/[id]/pages/analyze/route.ts
+++ b/app/api/v1/sites/[id]/pages/analyze/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SITES_ENDPOINTS } from '@/lib/backend-api';
+
+function getAuthHeader(request: NextRequest): string | null {
+  return request.headers.get('authorization');
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = getAuthHeader(request);
+  if (!auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const res = await fetch(SITES_ENDPOINTS.pagesAnalyze(id), {
+      method: 'POST',
+      headers: {
+        Authorization: auth,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error('Pages analyze proxy error:', e);
+    return NextResponse.json(
+      { message: 'Unable to reach backend' },
+      { status: 502 }
+    );
+  }
+}

--- a/lib/backend-api.ts
+++ b/lib/backend-api.ts
@@ -27,6 +27,10 @@ export const SITES_ENDPOINTS = {
   detail: (id: number | string) => `${getBackendApiUrl()}/api/v1/sites/${id}/`,
   overview: (id: number | string) =>
     `${getBackendApiUrl()}/api/v1/sites/${id}/overview/`,
+  pagesAnalyze: (id: number | string) =>
+    `${getBackendApiUrl()}/api/v1/sites/${id}/pages/analyze/`,
+  pagesAnalysis: (id: number | string) =>
+    `${getBackendApiUrl()}/api/v1/sites/${id}/pages/analysis/`,
 };
 
 export const API_KEYS_ENDPOINTS = {
@@ -56,3 +60,4 @@ export const SCAN_ENDPOINTS = {
   report: (id: number | string) =>
     `${getBackendApiUrl()}/api/v1/scans/${id}/report/`,
 };
+


### PR DESCRIPTION
## Problem
The Analyze button on the Pages tab showed 'Analysis failed - Failed to fetch' because the Next.js dashboard was missing proxy routes for:
- `POST /api/v1/sites/[id]/pages/analyze/`
- `GET /api/v1/sites/[id]/pages/analysis/`

The frontend calls these via `fetchWithAuth()` which routes through Next.js, but no corresponding `route.ts` files existed. Requests fell into a 404, causing the 'Failed to fetch' error.

## Fix
- Added `app/api/v1/sites/[id]/pages/analyze/route.ts` — POST proxy to Django backend
- Added `app/api/v1/sites/[id]/pages/analysis/route.ts` — GET proxy to Django backend
- Added `pagesAnalyze` and `pagesAnalysis` to `SITES_ENDPOINTS` in `lib/backend-api.ts`

## Testing
After deploy: click Analyze on any page in the Pages tab — should return Three-Layer content recommendations instead of 'Failed to fetch'.