### PR TITLE
feat: verification result banner + apply proxy route

### DIFF
--- a/app/api/v1/sites/[id]/pages/analysis/[analysisId]/apply/route.ts
+++ b/app/api/v1/sites/[id]/pages/analysis/[analysisId]/apply/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SITES_ENDPOINTS } from '@/lib/backend-api';
+
+function getAuthHeader(request: NextRequest): string | null {
+  return request.headers.get('authorization');
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; analysisId: string }> }
+) {
+  const auth = getAuthHeader(request);
+  if (!auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const { id, analysisId } = await params;
+    const url = `${SITES_ENDPOINTS.pagesAnalysis(id)}${analysisId}/apply/`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: auth, Accept: 'application/json', 'Content-Type': 'application/json' },
+    });
+    const data = await res.json();
+    if (!res.ok) return NextResponse.json(data, { status: res.status });
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error('Pages analysis apply proxy error:', e);
+    return NextResponse.json({ message: 'Unable to reach backend' }, { status: 502 });
+  }
+}

--- a/components/screens/PagesScreen.tsx
+++ b/components/screens/PagesScreen.tsx
@@ -284,6 +284,7 @@ function RecommendationPanel({
   const { toast } = useToast();
   const [isApplying, setIsApplying] = useState(false);
   const [applied, setApplied] = useState(false);
+  const [applyResult, setApplyResult] = useState<{verified: string[], unverified: string[], failed: Array<{rec_id: string, error: string}>} | null>(null);
 
   const handleApply = async () => {
     if (selectedRecs.size === 0) return;
@@ -294,8 +295,9 @@ function RecommendationPanel({
         analysis.id,
         Array.from(selectedRecs)
       );
-      await analysisService.applyToWordPress(siteId, analysis.id);
+      const result = await analysisService.applyToWordPress(siteId, analysis.id);
       setApplied(true);
+      setApplyResult({ verified: (result as any)?.verified || [], unverified: (result as any)?.unverified || [], failed: (result as any)?.failed || [] });
       toast({ title: 'Changes applied to WordPress!' });
       // Optimistically mark applied
       onApplySuccess({
@@ -411,6 +413,26 @@ function RecommendationPanel({
           Dismiss
         </Button>
       </div>
+
+      {applyResult && (
+        <div className="mt-3 space-y-1 text-sm">
+          {applyResult.verified.length > 0 && (
+            <div className="flex items-center gap-2 text-green-700 bg-green-50 rounded px-3 py-2">
+              ✅ {applyResult.verified.length} change{applyResult.verified.length !== 1 ? 's' : ''} verified live on WordPress
+            </div>
+          )}
+          {applyResult.unverified.length > 0 && (
+            <div className="flex items-center gap-2 text-yellow-700 bg-yellow-50 rounded px-3 py-2">
+              ⏳ {applyResult.unverified.length} applied — not yet confirmed on live page
+            </div>
+          )}
+          {applyResult.failed.length > 0 && (
+            <div className="flex items-center gap-2 text-red-700 bg-red-50 rounded px-3 py-2">
+              ❌ {applyResult.failed.length} failed — check recommendations panel
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/backend-api.ts
+++ b/lib/backend-api.ts
@@ -31,6 +31,8 @@ export const SITES_ENDPOINTS = {
     `${getBackendApiUrl()}/api/v1/sites/${id}/pages/analyze/`,
   pagesAnalysis: (id: number | string) =>
     `${getBackendApiUrl()}/api/v1/sites/${id}/pages/analysis/`,
+  pagesAnalysisApply: (id: number | string, analysisId: number | string) =>
+    `${getBackendApiUrl()}/api/v1/sites/${id}/pages/analysis/${analysisId}/apply/`,
 };
 
 export const API_KEYS_ENDPOINTS = {

--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -779,15 +779,23 @@ class AnalysisService {
     }
   }
 
-  async applyToWordPress(siteId: number | string, analysisId: number): Promise<void> {
+  async applyToWordPress(siteId: number | string, analysisId: number): Promise<{
+    applied: string[];
+    failed: Array<{rec_id: string; error: string}>;
+    verified: string[];
+    unverified: string[];
+    verification_details: Record<string, {found: boolean; field: string}>;
+    analysis_id: number;
+  }> {
     const res = await fetchWithAuth(
       `/api/v1/sites/${siteId}/pages/analysis/${analysisId}/apply/`,
       { method: 'POST', headers: { 'Content-Type': 'application/json' } }
     );
+    const data = await res.json();
     if (!res.ok) {
-      const data = await res.json();
       throw new Error(data.message || data.detail || data.error || 'Failed to apply to WordPress');
     }
+    return data;
   }
 }
 


### PR DESCRIPTION
Shows verified/unverified/failed banners after apply. Adds missing apply proxy route. Updates applyToWordPress to return verification data.