### PR TITLE
feat: onboarding nudges — getting started card, analyze warning, post-connect redirect

### DIFF
--- a/app/dashboard/dashboard.tsx
+++ b/app/dashboard/dashboard.tsx
@@ -19,6 +19,7 @@ const Settings = lazy(() => import('@/components/screens/Settings'));
 const PagesScreen = lazy(() => import('@/components/screens/PagesScreen'));
 const InternalLinks = lazy(() => import('@/components/screens/InternalLinks'));
 const SearchConsole = lazy(() => import('@/components/screens/SearchConsole'));
+const GettingStartedCard = lazy(() => import('@/components/onboarding/GettingStartedCard'));
 const GenerateModal = lazy(() => import('@/components/modals/GenerateModal'));
 const ApprovalModal = lazy(() => import('@/components/modals/ApprovalModal'));
 const CannibalizationModal = lazy(() => import('@/components/modals/CannibalizationModal'));
@@ -129,15 +130,28 @@ export default function Dashboard({
       case 'overview':
       case 'conflicts':
         return (
-          <GovernanceDashboard
-            healthScore={healthScore}
-            cannibalizationIssues={cannibalizationIssues}
-            silos={silos}
-            pendingChanges={pendingChanges}
-            onViewSilo={() => onTabChange?.('silos')}
-            onViewApprovals={() => onTabChange?.('approvals')}
-            onShowApprovalModal={() => setShowApprovalModal(true)}
-          />
+          <>
+            {activeTab === 'dashboard' && (
+              <Suspense fallback={null}>
+                <GettingStartedCard
+                  siteId={selectedSite.id}
+                  onNavigate={(tab, subtab) => {
+                    if (subtab) sessionStorage.setItem('siloq_settings_subtab', subtab);
+                    onTabChange?.(tab as TabType);
+                  }}
+                />
+              </Suspense>
+            )}
+            <GovernanceDashboard
+              healthScore={healthScore}
+              cannibalizationIssues={cannibalizationIssues}
+              silos={silos}
+              pendingChanges={pendingChanges}
+              onViewSilo={() => onTabChange?.('silos')}
+              onViewApprovals={() => onTabChange?.('approvals')}
+              onShowApprovalModal={() => setShowApprovalModal(true)}
+            />
+          </>
         );
       case 'keyword-registry':
         return <KeywordRegistry />;
@@ -154,7 +168,14 @@ export default function Dashboard({
       case 'approvals':
         return <ApprovalQueue pendingChanges={pendingChanges} siteId={selectedSite?.id || 0} />;
       case 'sites':
-        return <SitesScreen />;
+        return (
+          <SitesScreen
+            onSiteCreated={() => {
+              sessionStorage.setItem('siloq_settings_subtab', 'business-profile');
+              onTabChange?.('settings');
+            }}
+          />
+        );
       case 'content':
         return <ContentHub />;
       case 'content-upload':
@@ -168,6 +189,10 @@ export default function Dashboard({
             onAnalyze={(pageIds) => {
               setSelectedPageIds(pageIds);
               setShowCannibalizationModal(true);
+            }}
+            onNavigateToSettings={() => {
+              sessionStorage.setItem('siloq_settings_subtab', 'business-profile');
+              onTabChange?.('settings');
             }}
           />
         );

--- a/components/onboarding/GettingStartedCard.tsx
+++ b/components/onboarding/GettingStartedCard.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CheckCircle2, Circle, ChevronRight, X } from 'lucide-react';
+import { entityProfileService } from '@/lib/services/api';
+
+interface GettingStartedCardProps {
+  siteId: number;
+  onNavigate: (tab: string, subtab?: string) => void;
+}
+
+interface Step {
+  id: string;
+  label: string;
+  description: string;
+  done: boolean;
+  cta?: string;
+  action?: () => void;
+}
+
+export default function GettingStartedCard({ siteId, onNavigate }: GettingStartedCardProps) {
+  const [profileComplete, setProfileComplete] = useState(false);
+  const [firstAnalysisDone, setFirstAnalysisDone] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const dismissKey = `siloq_onboarding_done_${siteId}`;
+    if (localStorage.getItem(dismissKey)) {
+      setDismissed(true);
+      return;
+    }
+
+    // Check first analysis
+    const analysisKey = `siloq_first_analysis_done_${siteId}`;
+    if (localStorage.getItem(analysisKey)) setFirstAnalysisDone(true);
+
+    // Check business profile
+    entityProfileService.get(siteId).then(profile => {
+      setProfileComplete(!!(profile?.business_name));
+    }).catch(() => {});
+  }, [siteId]);
+
+  const steps: Step[] = [
+    {
+      id: 'site',
+      label: 'Connect your WordPress site',
+      description: 'Your site is connected and pages are syncing.',
+      done: true,
+    },
+    {
+      id: 'profile',
+      label: 'Complete your Business Profile',
+      description: 'Powers schema generation and GEO recommendations.',
+      done: profileComplete,
+      cta: 'Set up now',
+      action: () => onNavigate('settings', 'business-profile'),
+    },
+    {
+      id: 'analysis',
+      label: 'Run your first page analysis',
+      description: 'Get Three-Layer SEO + GEO + CRO recommendations.',
+      done: firstAnalysisDone,
+      cta: 'Go to Pages',
+      action: () => onNavigate('pages'),
+    },
+  ];
+
+  const completedCount = steps.filter(s => s.done).length;
+  const allDone = completedCount === steps.length;
+
+  // Auto-dismiss when all steps done
+  useEffect(() => {
+    if (allDone) {
+      localStorage.setItem(`siloq_onboarding_done_${siteId}`, '1');
+      setDismissed(true);
+    }
+  }, [allDone, siteId]);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    localStorage.setItem(`siloq_onboarding_done_${siteId}`, '1');
+    setDismissed(true);
+  };
+
+  return (
+    <div className="mb-4 rounded-xl border border-indigo-100 bg-gradient-to-br from-indigo-50 to-white p-5 shadow-sm">
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-semibold text-indigo-900">🚀 Finish setting up Siloq</h3>
+          <p className="text-xs text-indigo-600 mt-0.5">{completedCount} of {steps.length} steps complete</p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-indigo-300 hover:text-indigo-500 transition-colors"
+          title="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full bg-indigo-100 rounded-full h-1.5 mb-4">
+        <div
+          className="bg-indigo-500 h-1.5 rounded-full transition-all duration-500"
+          style={{ width: `${(completedCount / steps.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="space-y-2.5">
+        {steps.map(step => (
+          <div key={step.id} className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0">
+              {step.done ? (
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+              ) : (
+                <Circle className="h-4 w-4 text-indigo-200" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className={`text-sm font-medium ${step.done ? 'text-slate-400 line-through' : 'text-slate-800'}`}>
+                {step.label}
+              </p>
+              {!step.done && (
+                <p className="text-xs text-slate-500 mt-0.5">{step.description}</p>
+              )}
+            </div>
+            {!step.done && step.action && (
+              <button
+                onClick={step.action}
+                className="flex-shrink-0 flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+              >
+                {step.cta}
+                <ChevronRight className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/screens/Settings.tsx
+++ b/components/screens/Settings.tsx
@@ -133,6 +133,15 @@ export default function Settings({
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Pick up subtab navigation from sessionStorage (set by onboarding nudges)
+  useEffect(() => {
+    const subtab = sessionStorage.getItem('siloq_settings_subtab');
+    if (subtab && ['profile', 'api-keys', 'team', 'agent-permissions', 'notifications', 'business-profile'].includes(subtab)) {
+      sessionStorage.removeItem('siloq_settings_subtab');
+      setActiveTab(subtab as TabId);
+    }
+  }, []);
+
   // Team state
   const tierConfig = TIER_CONFIGS[resolvedTier];
   const maxTeammates = tierConfig.maxTeammates;

--- a/components/screens/SitesScreen.tsx
+++ b/components/screens/SitesScreen.tsx
@@ -57,7 +57,11 @@ const BACKEND_API_URL =
       ).replace(/\/+$/, '')
     : 'https://api.siloq.ai';
 
-export default function SitesScreen() {
+interface SitesScreenProps {
+  onSiteCreated?: () => void;
+}
+
+export default function SitesScreen({ onSiteCreated }: SitesScreenProps = {}) {
   const [sites, setSites] = useState<Site[]>([]);
   const [selectedSite, setSelectedSite] = useState<Site | null>(null);
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
@@ -243,6 +247,7 @@ export default function SitesScreen() {
       setNewSiteUrl('');
       toast.success('Site added successfully!');
       loadSites();
+      onSiteCreated?.();
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : 'Failed to create site');
     } finally {


### PR DESCRIPTION
## What
Three complementary nudges to ensure new users fill out Business Profile during onboarding.

## Features

### 1. Getting Started Card (Dashboard tab)
- Checklist card shown on the main dashboard until all 3 steps complete
- Steps: ✅ Connect site → ⬜ Business Profile → ⬜ First Analysis
- Progress bar, auto-dismisses when all done, manual dismiss option
- `localStorage` persists dismissal per site

### 2. Analyze-time Warning (Pages tab)
- When user clicks Analyze, silently checks if Business Profile is empty
- Shows non-blocking yellow banner: *'Business Profile incomplete — schema accuracy is reduced'*
- One-click link navigates to Settings > Business Profile
- Dismissable

### 3. Post-Connect Redirect (Sites / Settings tab)
- After successfully adding a new WordPress site → redirects to Settings > Business Profile
- Uses `sessionStorage` to pass subtab target across navigation

### 4. Settings Subtab Pickup
- Settings component reads `siloq_settings_subtab` from sessionStorage on mount
- Applies to any future flow that wants to deep-link into a settings tab

## Files changed
- `components/onboarding/GettingStartedCard.tsx` (new)
- `app/dashboard/dashboard.tsx`
- `components/screens/PagesScreen.tsx`
- `components/screens/SitesScreen.tsx`
- `components/screens/Settings.tsx`