### PR TITLE
fix: team invite flow — /invite page (404), accept endpoint, role editing

### DIFF
--- a/app/api/v1/team/invite/accept/route.ts
+++ b/app/api/v1/team/invite/accept/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const getBackendUrl = () =>
+  (process.env.BACKEND_API_URL || process.env.NEXT_PUBLIC_BACKEND_API_URL || 'https://api.siloq.ai').replace(/\/+$/, '');
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const res = await fetch(`${getBackendUrl()}/api/v1/auth/team/invite/accept/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'Unable to reach backend' }, { status: 502 });
+  }
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -78,7 +78,11 @@ export default function LoginPage() {
         if (name) localStorage.setItem('userName', name);
         if (data.user.email) localStorage.setItem('userEmail', data.user.email);
       }
-      router.push('/dashboard');
+      // Redirect to invite acceptance page if coming from an invite link
+      const inviteToken = typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('invite')
+        : null;
+      router.push(inviteToken ? `/invite?token=${inviteToken}` : '/dashboard');
     } catch (err: any) {
       setError(err.message);
     } finally {

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -173,7 +173,11 @@ export default function RegisterPage() {
 
       setIsSuccess(true);
       setTimeout(() => {
-        router.push('/auth/login');
+        // If user came from an invite link, send them back to complete acceptance
+        const inviteToken = typeof window !== 'undefined'
+          ? new URLSearchParams(window.location.search).get('invite')
+          : null;
+        router.push(inviteToken ? `/invite?token=${inviteToken}` : '/auth/login');
       }, 2000);
     } catch (err: any) {
       setError(err.message);

--- a/app/invite/page.tsx
+++ b/app/invite/page.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useEffect, useState, Suspense } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+type InviteState =
+  | { status: 'loading' }
+  | { status: 'accepted'; siteName: string; role: string }
+  | { status: 'already_member'; siteName: string }
+  | { status: 'register'; email: string; token: string; siteName: string; invitedBy: string; role: string }
+  | { status: 'error'; message: string };
+
+function InviteContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token') || '';
+  const [state, setState] = useState<InviteState>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!token) {
+      setState({ status: 'error', message: 'Invalid invitation link — no token found.' });
+      return;
+    }
+
+    const accept = async () => {
+      try {
+        const res = await fetch('/api/v1/team/invite/accept/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+
+        const data = await res.json();
+
+        if (res.status === 202 && data.action === 'register') {
+          // User needs to create an account first
+          setState({
+            status: 'register',
+            email: data.email,
+            token,
+            siteName: data.site_name,
+            invitedBy: data.invited_by,
+            role: data.role,
+          });
+          return;
+        }
+
+        if (res.ok && data.accepted) {
+          if (data.already_had_access) {
+            setState({ status: 'already_member', siteName: data.site?.name || 'the site' });
+          } else {
+            setState({ status: 'accepted', siteName: data.site?.name || 'the site', role: data.role });
+          }
+          return;
+        }
+
+        setState({ status: 'error', message: data.error || 'Something went wrong. The link may have expired.' });
+      } catch {
+        setState({ status: 'error', message: 'Unable to reach Siloq. Please try again.' });
+      }
+    };
+
+    accept();
+  }, [token]);
+
+  if (state.status === 'loading') {
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+        <p className="text-slate-600">Verifying your invitation…</p>
+      </div>
+    );
+  }
+
+  if (state.status === 'accepted') {
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 text-3xl">
+          ✅
+        </div>
+        <h1 className="mb-2 text-2xl font-bold text-slate-900">You&apos;re in!</h1>
+        <p className="mb-6 text-slate-600">
+          You now have <strong className="capitalize">{state.role}</strong> access to{' '}
+          <strong>{state.siteName}</strong>.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-6 py-3 font-semibold text-white hover:bg-indigo-700"
+        >
+          Go to Dashboard →
+        </Link>
+      </div>
+    );
+  }
+
+  if (state.status === 'already_member') {
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 text-3xl">
+          👋
+        </div>
+        <h1 className="mb-2 text-2xl font-bold text-slate-900">Already a member</h1>
+        <p className="mb-6 text-slate-600">
+          You already have access to <strong>{state.siteName}</strong>.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-6 py-3 font-semibold text-white hover:bg-indigo-700"
+        >
+          Go to Dashboard →
+        </Link>
+      </div>
+    );
+  }
+
+  if (state.status === 'register') {
+    const registerUrl = `/auth/register?invite=${encodeURIComponent(state.token)}&email=${encodeURIComponent(state.email)}`;
+    const loginUrl = `/auth/login?invite=${encodeURIComponent(state.token)}`;
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100 text-3xl">
+          🎉
+        </div>
+        <h1 className="mb-2 text-2xl font-bold text-slate-900">You&apos;ve been invited!</h1>
+        <p className="mb-1 text-slate-600">
+          <strong>{state.invitedBy}</strong> invited you to join{' '}
+          <strong>{state.siteName}</strong> as a{' '}
+          <strong className="capitalize">{state.role}</strong>.
+        </p>
+        <p className="mb-6 text-sm text-slate-500">
+          Invited as <strong>{state.email}</strong>
+        </p>
+        <div className="flex flex-col gap-3">
+          <Link
+            href={registerUrl}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-6 py-3 font-semibold text-white hover:bg-indigo-700"
+          >
+            Create your account →
+          </Link>
+          <Link
+            href={loginUrl}
+            className="text-sm text-indigo-600 underline hover:text-indigo-800"
+          >
+            Already have an account? Log in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  return (
+    <div className="text-center">
+      <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-3xl">
+        ❌
+      </div>
+      <h1 className="mb-2 text-2xl font-bold text-slate-900">Invalid invitation</h1>
+      <p className="mb-6 text-slate-600">{(state as { status: 'error'; message: string }).message}</p>
+      <Link
+        href="/auth/login"
+        className="text-sm text-indigo-600 underline hover:text-indigo-800"
+      >
+        Go to login
+      </Link>
+    </div>
+  );
+}
+
+export default function InvitePage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-lg">
+        <div className="mb-6 text-center">
+          <h2 className="text-3xl font-bold text-indigo-600">Siloq</h2>
+        </div>
+        <Suspense
+          fallback={
+            <div className="text-center text-slate-500">Loading…</div>
+          }
+        >
+          <InviteContent />
+        </Suspense>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Bugs Fixed

### 1. /invite?token=... → 404
- Created `app/invite/page.tsx` — the missing page that invite emails link to
- Handles all states: loading → accepted ✅ / already member 👋 / needs to register 🎉 / error ❌
- After register/login with invite token → redirects back to complete acceptance

### 2. Team members not appearing after accepting
- Created `app/api/v1/team/invite/accept/route.ts` proxy
- Calls the new `accept_invite` backend endpoint (see siloq-api PR)
- Backend creates `SiteAccess` record, marks invite accepted

### 3. Can't edit role (viewer → admin)
- Wired up the Edit button in `Settings.tsx` — it was a dead button with no handler
- Now opens inline role selector: Viewer / Editor / Admin dropdown + Save/Cancel
- Calls `PATCH /api/v1/auth/team/{id}/role/` on save
- Updates local state immediately on success

### 4. Post-login/register invite completion
- `auth/login/page.tsx`: if `?invite=TOKEN` in URL → redirect to `/invite?token=TOKEN` after login
- `auth/register/page.tsx`: same for new users completing registration