### PR TITLE
fix: stop crash after site creation, fix Sites tab redirect

### DIFF
--- a/app/dashboard/dashboard.tsx
+++ b/app/dashboard/dashboard.tsx
@@ -70,6 +70,7 @@ export default function Dashboard({
     pendingChanges,
     linkOpportunities,
     isLoading,
+    loadSites,
     loadCannibalization,
     loadSilos,
     loadRecommendations,
@@ -173,8 +174,9 @@ export default function Dashboard({
         return (
           <SitesScreen
             onSiteCreated={() => {
-              sessionStorage.setItem('siloq_settings_subtab', 'business-profile');
-              onTabChange?.('settings');
+              // Stay on Sites after creation — SitesScreen reloads the list and shows success toast.
+              // Reload the dashboard context so the new site gets picked up.
+              loadSites();
             }}
           />
         );


### PR DESCRIPTION
## Root Cause
After adding a site, `onSiteCreated` redirected to Settings > Business Profile. But the dashboard context hadn't reloaded — so `selectedSite` was still null or stale, causing an unhandled exception on the settings page.

Also: `'sites': 'settings'` was in the TAB_REDIRECTS table (already removed in the latest branch), which silently sent every Sites nav click to Settings.

## Fix
- `onSiteCreated` now stays on the Sites screen and calls `loadSites()` to reload the context with the new site
- Added `loadSites` to the `useDashboardContext()` destructure in dashboard.tsx

## Result
After adding a site: site appears in the list immediately, no redirect, no crash.