### PR TITLE
fix: normalize entity profile response after save (page crash fix)

### DIFF
--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -917,7 +917,7 @@ class EntityProfileService {
     });
     const data = await res.json();
     if (!res.ok) throw new Error(data.message || 'Failed to update entity profile');
-    return data;
+    return this.normalize(data);
   }
 
   async syncGbp(siteId: number | string, placeIdOrUrl: string, phone?: string): Promise<EntityProfile> {


### PR DESCRIPTION
## Problem
After GBP sync succeeds and user clicks "Save Business Profile", the entire page crashes with:
> Application error: a client-side exception has occurred while loading app.siloq.ai

## Root Cause
`entityProfileService.update()` returned raw API response (`return data`) without calling `normalize()`. The raw PATCH response doesn't have `social_profiles` in the nested format the component expects. When `setProfile(updated)` is called with raw data:

```tsx
// Crashes: profile.social_profiles is undefined
<Input value={profile.social_profiles[platform]} />
```

`get()` and `syncGbp()` both already called `normalize()` — `update()` was the only one that didn't.

## Fix
One-line: `return this.normalize(data);`