### PR TITLE
fix: reload profile from API after save (Business Profile content disappears fix)

### DIFF
--- a/components/settings/BusinessProfileSettings.tsx
+++ b/components/settings/BusinessProfileSettings.tsx
@@ -46,8 +46,11 @@ export default function BusinessProfileSettings({ siteId }: Props) {
     if (!profile) return;
     setSaving(true); setError(null);
     try {
-      const updated = await entityProfileService.update(siteId, profile);
-      setProfile(updated); setSaved(true);
+      await entityProfileService.update(siteId, profile);
+      // Reload from API after save to guarantee we display what's actually persisted
+      const refreshed = await entityProfileService.get(siteId);
+      setProfile(refreshed);
+      setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (e: any) { setError(e.message); }
     finally { setSaving(false); }


### PR DESCRIPTION
## Problem
After clicking 'Save Business Profile', the form shows the Saved toast but all content disappears.

## Root Cause
After PATCH, the UI called `setProfile(updated)` using the PATCH response. If the PATCH response was incomplete or the normalize() call resulted in empty defaults, the profile would appear blank.

## Fix
After a successful PATCH, do a fresh GET to reload the canonical profile from the API:
```
await entityProfileService.update(siteId, profile);   // PATCH (write)
const refreshed = await entityProfileService.get(siteId); // GET (verify)
setProfile(refreshed);                                    // render accurate data
```

This guarantees the UI always shows what's actually persisted in the DB, not what the PATCH response happened to return.