### PR TITLE
fix: update plugin download links to v1.5.9

### DIFF
--- a/components/screens/Settings.tsx
+++ b/components/screens/Settings.tsx
@@ -586,7 +586,7 @@ export default function Settings({
         </h4>
         <div className="mb-4">
           <a
-            href="https://github.com/Siloq-app/siloq-wordpress/releases/download/v1.5.8/siloq-connector-v1.5.8.zip"
+            href="https://github.com/Siloq-app/siloq-wordpress/releases/download/v1.5.9/siloq-connector-v1.5.9.zip"
             download
             className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-blue-600 px-4 text-sm font-medium text-white shadow transition-colors hover:bg-blue-700"
           >

--- a/components/screens/SitesScreen.tsx
+++ b/components/screens/SitesScreen.tsx
@@ -15,7 +15,7 @@ import {
   Download,
 } from 'lucide-react';
 
-const PLUGIN_DOWNLOAD_URL = 'https://github.com/Siloq-app/siloq-wordpress/releases/download/v1.5.8/siloq-connector-v1.5.8.zip';
+const PLUGIN_DOWNLOAD_URL = 'https://github.com/Siloq-app/siloq-wordpress/releases/download/v1.5.9/siloq-connector-v1.5.9.zip';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';


### PR DESCRIPTION
Updates download URLs to v1.5.9 (fixes webhook payload — publish button now works).