### PR TITLE
fix: prevent cross-site page bleed in PagesScreen

### DIFF
--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -169,7 +169,8 @@ class SitesService {
 
 class PagesService {
   async list(siteId?: number | string): Promise<Page[]> {
-    const url = siteId ? `/api/v1/pages?site_id=${siteId}` : '/api/v1/pages';
+    if (!siteId) return [];
+    const url = `/api/v1/pages/?site_id=${siteId}`;
     const res = await fetchWithAuth(url);
     const data = await res.json();
     if (!res.ok)


### PR DESCRIPTION
## Problem
When viewing any site's Pages tab, pages from **other connected sites** were appearing in the list (e.g. theremodelco.com and cocoeventsnyc.com pages showing under Lioncraft Roofing).

## Root Cause
If `siteId` was momentarily falsy during a site switch (React async state update timing), `loadPages` would fire a request to `/api/v1/pages/` **without** a `site_id` filter. The backend correctly returns all pages for the authenticated user — which spans all 15 connected sites, up to the 1000-page pagination cap — and all those pages would render in the active site's view.

## Fixes

### `components/screens/PagesScreen.tsx`
- **Guard**: `loadPages` now returns early with empty state if `siteId` is falsy — never issues an unfiltered request
- **AbortController**: Cancels the in-flight fetch if `siteId` changes before the response arrives (prevents race condition where old site's data overwrites new site's data)
- **State reset**: Clears `pages`, `currentPage`, and `error` immediately when `siteId` changes — no more stale data from previous site briefly flashing

### `lib/services/api.ts`
- `pagesService.list()` now returns `[]` immediately when `siteId` is falsy, instead of issuing an unfiltered request

## Testing
1. Connect 2+ sites with different pages
2. Switch between sites in the header dropdown
3. Confirm pages always match the selected site, no cross-site bleed