### PR TITLE
feat: Cannibalization Intelligence + Supporting Content CTA in page analysis

### DIFF
--- a/app/dashboard/dashboard.tsx
+++ b/app/dashboard/dashboard.tsx
@@ -183,9 +183,9 @@ export default function Dashboard({
           />
         );
       case 'schema':
-        return <SchemaArchitect siteId={siteId} apiBase={process.env.NEXT_PUBLIC_API_URL || ''} wpApiBase={siteUrl} wpApiKey={siteApiKey} />;
+        return <SchemaArchitect siteId={selectedSite?.id || 0} apiBase={process.env.NEXT_PUBLIC_API_URL || ''} wpApiBase={selectedSite?.url || ''} wpApiKey={''} />;
       case 'freshness':
-        return <FreshnessTab siteId={siteId} apiBase={process.env.NEXT_PUBLIC_API_URL || ''} />;
+        return <FreshnessTab siteId={selectedSite?.id || 0} apiBase={process.env.NEXT_PUBLIC_API_URL || ''} />;
       case 'content':
         return <ContentHub />;
       case 'content-upload':

--- a/app/dashboard/types.ts
+++ b/app/dashboard/types.ts
@@ -12,7 +12,7 @@ export type TabType =
   | 'conflicts'
   | 'keyword-registry'
   | 'silo-health'
-  | 'content-upload';
+  | 'content-upload'
   | 'schema'
   | 'freshness';
 export type AutomationMode = 'manual' | 'semi' | 'full';

--- a/components/screens/CannibalizationIntelligence.tsx
+++ b/components/screens/CannibalizationIntelligence.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+/**
+ * CannibalizationIntelligence
+ *
+ * Renders the Informational Gain + Geographic Grounding intelligence
+ * directly inside the page analysis RecommendationPanel.
+ *
+ * Uses real API field names (confirmed from geographic_grounding.py):
+ *   informational_gain.unique_percentage  (0–100 score)
+ *   informational_gain.label              (strong | moderate | weak | none)
+ *   informational_gain.unique_ratio
+ *   informational_gain.max_similarity_to_hub
+ *   informational_gain.swap_pattern_detected
+ *   informational_gain.recommendations[]
+ *
+ *   geographic_grounding.is_location_page
+ *   geographic_grounding.target_location
+ *   geographic_grounding.grounding_status  (strong | weak | none | unknown)
+ *   geographic_grounding.grounding_signals[]
+ *   geographic_grounding.missing_signals[]
+ *   geographic_grounding.warning_message
+ *   geographic_grounding.recommendations[]
+ *
+ * Spec: Informational Gain + Geographic Grounding UI Spec v1.0
+ */
+
+import { useState } from 'react';
+import { ChevronDown, ChevronUp, CheckCircle2, XCircle, AlertTriangle, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface InformationalGain {
+  unique_percentage: number;
+  unique_ratio: number;
+  label: 'strong' | 'moderate' | 'weak' | 'none';
+  emoji?: string;
+  warning: boolean;
+  swap_pattern_detected?: boolean;
+  max_similarity_to_hub?: number;
+  avg_similarity_to_hub?: number;
+  recommendations: string[];
+  note?: string;
+}
+
+interface GeographicGrounding {
+  is_location_page: boolean;
+  target_location: string | null;
+  grounding_status: 'strong' | 'weak' | 'none' | 'unknown' | null;
+  grounding_signals: string[];
+  missing_signals: string[];
+  warning: boolean;
+  warning_message: string | null;
+  recommendations: string[];
+}
+
+export interface PageAnalysisWithIntelligence {
+  informational_gain?: InformationalGain;
+  geographic_grounding?: GeographicGrounding;
+  // forward-compat — the rest of the analysis object lives here too
+  [key: string]: unknown;
+}
+
+interface CannibalizationIntelligenceProps {
+  analysis: PageAnalysisWithIntelligence;
+  onReanalyze?: () => void;
+}
+
+// ── Score helpers ─────────────────────────────────────────────────────────────
+
+type ScoreColor = { bg: string; text: string; border: string; badge: string };
+
+function labelToColor(label: string | null | undefined): ScoreColor {
+  switch (label) {
+    case 'strong': return { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200', badge: 'bg-green-100 text-green-700' };
+    case 'moderate': return { bg: 'bg-amber-50', text: 'text-amber-700', border: 'border-amber-200', badge: 'bg-amber-100 text-amber-700' };
+    case 'weak': return { bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200', badge: 'bg-orange-100 text-orange-700' };
+    case 'none': return { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200', badge: 'bg-red-100 text-red-700' };
+    default: return { bg: 'bg-slate-50', text: 'text-slate-600', border: 'border-slate-200', badge: 'bg-slate-100 text-slate-600' };
+  }
+}
+
+function statusLabel(label: string | null | undefined): string {
+  switch (label) {
+    case 'strong': return 'Strong';
+    case 'moderate': return 'Moderate';
+    case 'weak': return 'Weak';
+    case 'none': return 'Critical';
+    case 'unknown': return 'Unknown';
+    default: return 'Not scored';
+  }
+}
+
+function similarityBadge(pct: number): string {
+  if (pct >= 70) return 'bg-red-100 text-red-700';
+  if (pct >= 50) return 'bg-orange-100 text-orange-700';
+  return 'bg-yellow-100 text-yellow-700';
+}
+
+// ── Signal name → human readable ─────────────────────────────────────────────
+
+const SIGNAL_LABELS: Record<string, string> = {
+  gbp_domain_matches: 'GBP listing links to this domain',
+  gbp_service_area_covers_location: 'GBP service area covers this city',
+  gbp_reviews_mention_location: 'Customer reviews mention this city',
+};
+
+function signalLabel(key: string): string {
+  return SIGNAL_LABELS[key] || key.replace(/_/g, ' ');
+}
+
+// ── Static tip content ────────────────────────────────────────────────────────
+
+const IG_TIPS = [
+  'Add a section unique to this city/service that does not appear on any other page.',
+  'Include a customer testimonial from someone in this specific area.',
+  'Reference a local project, job site, or area-specific scenario.',
+  'Cover a service angle or problem type that differs from your other pages.',
+  'Review your other similar pages and consciously differentiate each one\'s opening paragraph.',
+];
+
+const GG_TIPS = [
+  'Add the target city\'s zip codes naturally in the content (e.g., "serving the 64118 and 64119 zip codes").',
+  'Reference a well-known local landmark, neighborhood, or road.',
+  'Mention a city-specific fact — population, local event, or area history.',
+  'Add a customer story or review that mentions the city by name.',
+  'Include the city name in at least one H2 or H3 heading on the page.',
+  'If you have photos from a local job, add alt text referencing the city.',
+];
+
+// ── Collapsible panel ─────────────────────────────────────────────────────────
+
+function Panel({
+  title,
+  score,
+  label,
+  defaultOpen,
+  children,
+}: {
+  title: string;
+  score: number;
+  label: string;
+  defaultOpen: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const colors = labelToColor(label);
+
+  return (
+    <div className={`rounded-lg border ${colors.border} overflow-hidden`}>
+      <button
+        className={`w-full flex items-center justify-between px-4 py-3 ${colors.bg} hover:opacity-90 transition-opacity`}
+        onClick={() => setOpen(o => !o)}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold text-slate-700">{title}</span>
+          <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${colors.badge}`}>
+            {score}/100
+          </span>
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${colors.badge}`}>
+            {statusLabel(label)}
+          </span>
+        </div>
+        {open ? <ChevronUp size={16} className="text-slate-400" /> : <ChevronDown size={16} className="text-slate-400" />}
+      </button>
+      {open && <div className="px-4 py-3 bg-white border-t border-slate-100">{children}</div>}
+    </div>
+  );
+}
+
+// ── Tips expander ─────────────────────────────────────────────────────────────
+
+function TipsPanel({ tips }: { tips: string[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-3">
+      <button
+        className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+        onClick={() => setOpen(o => !o)}
+      >
+        {open ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        How to fix this
+      </button>
+      {open && (
+        <ul className="mt-2 space-y-1.5 pl-1">
+          {tips.map((tip, i) => (
+            <li key={i} className="flex gap-2 text-xs text-slate-600">
+              <span className="text-blue-400 flex-shrink-0 mt-0.5">→</span>
+              <span>{tip}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function CannibalizationIntelligence({
+  analysis,
+  onReanalyze,
+}: CannibalizationIntelligenceProps) {
+  const ig = analysis?.informational_gain as InformationalGain | undefined;
+  const gg = analysis?.geographic_grounding as GeographicGrounding | undefined;
+
+  // If neither field present → data was analyzed before these features shipped
+  if (!ig && !gg) {
+    return (
+      <div className="mt-6 border-t border-slate-100 pt-5">
+        <div className="flex items-center gap-2 mb-1">
+          <Zap size={16} className="text-slate-400" />
+          <h3 className="text-sm font-semibold text-slate-700">Cannibalization Intelligence</h3>
+        </div>
+        <div className="flex items-center gap-3 p-3 bg-amber-50 rounded-lg border border-amber-100 text-sm text-amber-700">
+          <AlertTriangle size={16} className="flex-shrink-0" />
+          <span>Re-analyze this page to see Cannibalization Intelligence scores.</span>
+          {onReanalyze && (
+            <Button size="sm" variant="outline" className="ml-auto text-xs h-7" onClick={onReanalyze}>
+              Re-analyze
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const igScore = ig ? Math.round(ig.unique_percentage) : null;
+  const igLabel = ig?.label ?? null;
+  const igAutoOpen = !!(ig && (ig.label === 'weak' || ig.label === 'none'));
+
+  const ggPresent = gg?.is_location_page === true;
+  const ggStatusLabel = gg?.grounding_status ?? null;
+  // Map GG status to numeric score for display (strong=85, weak=35, none=10, unknown=0)
+  const ggScore = ggStatusLabel === 'strong' ? 85
+    : ggStatusLabel === 'weak' ? 35
+    : ggStatusLabel === 'none' ? 10
+    : ggStatusLabel === 'unknown' ? 0
+    : null;
+  const ggAutoOpen = !!(gg && gg.warning);
+
+  return (
+    <div className="mt-6 border-t border-slate-100 pt-5">
+      {/* Section header */}
+      <div className="flex items-center gap-2 mb-3">
+        <Zap size={16} className="text-slate-500" />
+        <h3 className="text-sm font-semibold text-slate-700">Cannibalization Intelligence</h3>
+        <span
+          className="text-slate-400 cursor-help text-xs border border-slate-200 rounded-full w-4 h-4 flex items-center justify-center"
+          title="Siloq analyzes your entire site to detect where pages are competing against each other."
+        >
+          ?
+        </span>
+      </div>
+
+      <div className="space-y-3">
+
+        {/* ── Informational Gain ─────────────────────────────────────────── */}
+        {ig && igScore !== null && (
+          <Panel
+            title="Informational Gain"
+            score={igScore}
+            label={igLabel ?? 'none'}
+            defaultOpen={igAutoOpen}
+          >
+            {/* Summary */}
+            <p className="text-xs text-slate-600 mb-3">
+              {ig.recommendations?.[0] || (
+                igScore >= 75
+                  ? 'This page is well differentiated — low cannibalization risk.'
+                  : igScore >= 50
+                  ? 'Some content overlap with similar pages. Consider adding more unique content.'
+                  : igScore >= 25
+                  ? 'Significant content duplication detected. Differentiate this page to avoid cannibalization.'
+                  : 'This page appears near-duplicate with other pages on your site. Google may suppress both.'
+              )}
+            </p>
+
+            {/* Stats row */}
+            <div className="flex flex-wrap gap-4 mb-3 text-xs text-slate-500">
+              <span>
+                <strong className={labelToColor(igLabel).text}>{igScore}%</strong> of content is unique to this page
+              </span>
+              {ig.max_similarity_to_hub !== undefined && (
+                <span>
+                  Most similar page:{' '}
+                  <span className={`font-medium ${similarityBadge(Math.round(ig.max_similarity_to_hub * 100)).replace('bg-', 'text-').replace('-100', '-700')}`}>
+                    {Math.round(ig.max_similarity_to_hub * 100)}% overlap
+                  </span>
+                </span>
+              )}
+              {ig.swap_pattern_detected && (
+                <span className="inline-flex items-center gap-1 text-red-600 font-medium">
+                  <AlertTriangle size={11} /> City-page template detected
+                </span>
+              )}
+            </div>
+
+            {/* Additional recommendations */}
+            {ig.recommendations && ig.recommendations.length > 1 && (
+              <ul className="space-y-1 mb-3">
+                {ig.recommendations.slice(1).map((rec, i) => (
+                  <li key={i} className="text-xs text-slate-500 flex gap-1.5">
+                    <span className="text-slate-300 flex-shrink-0">•</span>
+                    <span>{rec}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <TipsPanel tips={IG_TIPS} />
+          </Panel>
+        )}
+
+        {/* ── Geographic Grounding ───────────────────────────────────────── */}
+        {ggPresent && gg && ggScore !== null && (
+          <Panel
+            title={`Geographic Grounding${gg.target_location ? ` — ${gg.target_location}` : ''}`}
+            score={ggScore}
+            label={ggStatusLabel ?? 'none'}
+            defaultOpen={ggAutoOpen}
+          >
+            {/* Summary message */}
+            {gg.warning_message && (
+              <p className="text-xs text-slate-600 mb-3">{gg.warning_message}</p>
+            )}
+
+            {/* Signals found */}
+            {gg.grounding_signals && gg.grounding_signals.length > 0 && (
+              <div className="mb-2">
+                <p className="text-xs font-medium text-slate-500 mb-1">Grounding signals found:</p>
+                <ul className="space-y-1">
+                  {gg.grounding_signals.map(signal => (
+                    <li key={signal} className="flex items-center gap-2 text-xs text-green-700">
+                      <CheckCircle2 size={13} className="text-green-500 flex-shrink-0" />
+                      {signalLabel(signal)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Signals missing */}
+            {gg.missing_signals && gg.missing_signals.length > 0 && (
+              <div className="mb-2">
+                <p className="text-xs font-medium text-slate-500 mb-1">Missing signals:</p>
+                <ul className="space-y-1">
+                  {gg.missing_signals.map(signal => (
+                    <li key={signal} className="flex items-center gap-2 text-xs text-red-600">
+                      <XCircle size={13} className="text-red-400 flex-shrink-0" />
+                      {signalLabel(signal)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Recommendations */}
+            {gg.recommendations && gg.recommendations.length > 0 && (
+              <ul className="space-y-1 mt-2 mb-1">
+                {gg.recommendations.map((rec, i) => (
+                  <li key={i} className="text-xs text-slate-500 flex gap-1.5">
+                    <span className="text-slate-300 flex-shrink-0">•</span>
+                    <span>{rec}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <TipsPanel tips={GG_TIPS} />
+          </Panel>
+        )}
+
+        {/* GG not applicable (non-location page) — render nothing */}
+
+      </div>
+    </div>
+  );
+}

--- a/components/screens/ContentHub.tsx
+++ b/components/screens/ContentHub.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from 'next/navigation';
 import { useDashboardContext } from '@/lib/hooks/dashboard-context';
 import { useTheme } from '@/lib/hooks/theme-context';
 import { fetchWithAuth } from '@/lib/auth-headers';
@@ -457,6 +458,9 @@ function SuccessBanner({ title, onDismiss }: { title: string; onDismiss: () => v
 export default function ContentHub() {
   const { theme: t, mode } = useTheme();
   const { selectedSite } = useDashboardContext();
+
+  // Deep-link: pre-filter from page analysis CTA (?page_id=xxx)
+  const searchParams = useSearchParams();
 
   // Page selector
   const [pages, setPages] = useState<SitePage[]>([]);

--- a/components/screens/PagesScreen.tsx
+++ b/components/screens/PagesScreen.tsx
@@ -32,7 +32,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { NoSiteSelected } from '@/components/ui/no-site-selected';
 import { useToast } from '@/components/ui/use-toast';
 import SupportingContentSection from './SupportingContentSection';
-import CannibalizationIntelligence from './CannibalizationIntelligence';
+import CannibalizationIntelligence, { PageAnalysisWithIntelligence } from './CannibalizationIntelligence';
 import { analysisService, entityProfileService, PageAnalysis, Recommendation } from '@/lib/services/api';
 import { FileText } from 'lucide-react';
 
@@ -475,7 +475,7 @@ function RecommendationPanel({
       {/* Status now shown inline in the actions bar above */}
 
       {/* Cannibalization Intelligence — IG + GG scores */}
-      <CannibalizationIntelligence analysis={analysis} onReanalyze={() => {}} />
+      <CannibalizationIntelligence analysis={analysis as unknown as PageAnalysisWithIntelligence} onReanalyze={() => {}} />
 
       {/* Supporting Content Section — Hub & Spoke gap detection */}
       <SupportingContentSection siteId={siteId} pageId={pageId} />

--- a/components/screens/PagesScreen.tsx
+++ b/components/screens/PagesScreen.tsx
@@ -32,6 +32,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { NoSiteSelected } from '@/components/ui/no-site-selected';
 import { useToast } from '@/components/ui/use-toast';
 import SupportingContentSection from './SupportingContentSection';
+import CannibalizationIntelligence from './CannibalizationIntelligence';
 import { analysisService, entityProfileService, PageAnalysis, Recommendation } from '@/lib/services/api';
 import { FileText } from 'lucide-react';
 
@@ -472,6 +473,9 @@ function RecommendationPanel({
       </div>
 
       {/* Status now shown inline in the actions bar above */}
+
+      {/* Cannibalization Intelligence — IG + GG scores */}
+      <CannibalizationIntelligence analysis={analysis} onReanalyze={() => {}} />
 
       {/* Supporting Content Section — Hub & Spoke gap detection */}
       <SupportingContentSection siteId={siteId} pageId={pageId} />

--- a/components/screens/PagesScreen.tsx
+++ b/components/screens/PagesScreen.tsx
@@ -31,6 +31,7 @@ import { ErrorState } from '@/components/ui/error-state';
 import { EmptyState } from '@/components/ui/empty-state';
 import { NoSiteSelected } from '@/components/ui/no-site-selected';
 import { useToast } from '@/components/ui/use-toast';
+import SupportingContentSection from './SupportingContentSection';
 import { analysisService, entityProfileService, PageAnalysis, Recommendation } from '@/lib/services/api';
 import { FileText } from 'lucide-react';
 
@@ -268,6 +269,7 @@ function LayerTabContent({
 interface RecommendationPanelProps {
   analysis: PageAnalysis;
   siteId: number | string;
+  pageId: number;
   selectedRecs: Set<string>;
   onToggleRec: (id: string) => void;
   onDismiss: () => void;
@@ -277,6 +279,7 @@ interface RecommendationPanelProps {
 function RecommendationPanel({
   analysis,
   siteId,
+  pageId,
   selectedRecs,
   onToggleRec,
   onDismiss,
@@ -469,6 +472,9 @@ function RecommendationPanel({
       </div>
 
       {/* Status now shown inline in the actions bar above */}
+
+      {/* Supporting Content Section — Hub & Spoke gap detection */}
+      <SupportingContentSection siteId={siteId} pageId={pageId} />
     </div>
   );
 }
@@ -1029,6 +1035,7 @@ export default function PagesScreen({ onAnalyze, siteId, onNavigateToSettings }:
                       <RecommendationPanel
                         analysis={analysis}
                         siteId={siteId}
+                        pageId={page.id}
                         selectedRecs={selectedRecommendations}
                         onToggleRec={handleToggleRec}
                         onDismiss={handleDismissPanel}

--- a/components/screens/SupportingContentSection.tsx
+++ b/components/screens/SupportingContentSection.tsx
@@ -78,7 +78,7 @@ export default function SupportingContentSection({
   const [error, setError] = useState(false);
   const [generatingId, setGeneratingId] = useState<string | null>(null);
   // Track optimistic status updates
-  const [optimisticStatus, setOptimisticStatus] = useState<Record<string, 'draft' | 'published'>>({});
+  const [optimisticStatus, setOptimisticStatus] = useState<Record<string, 'missing' | 'draft' | 'published'>>({});
 
   const load = useCallback(async () => {
     setLoading(true);

--- a/components/screens/SupportingContentSection.tsx
+++ b/components/screens/SupportingContentSection.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+/**
+ * SupportingContentSection
+ *
+ * Renders inside the page analysis RecommendationPanel, directly below
+ * existing recommendations. Shows supporting content gaps for the current
+ * page and provides a path to Content Hub to generate the missing articles.
+ *
+ * Spec: jumar-spec-supporting-content-cta.md
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { fetchWithAuth } from '@/lib/auth-headers';
+import { useToast } from '@/components/ui/use-toast';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  CheckCircle,
+  AlertCircle,
+  ArrowRight,
+  RefreshCw,
+  Sparkles,
+  BookOpen,
+  TrendingUp,
+} from 'lucide-react';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface RecommendedArticle {
+  id: string;
+  suggested_title: string;
+  target_keyword: string;
+  search_volume: number;
+  intent: 'informational' | 'commercial' | 'transactional' | 'navigational';
+  status: 'missing' | 'draft' | 'published';
+}
+
+interface SupportingContentData {
+  gaps_detected: number;
+  recommended_articles: RecommendedArticle[];
+  generated_count: number;
+  published_count: number;
+}
+
+interface SupportingContentSectionProps {
+  siteId: number | string;
+  pageId: number;
+}
+
+// ── Intent badge colors ───────────────────────────────────────────────────────
+
+const INTENT_COLORS: Record<string, string> = {
+  informational: 'bg-blue-100 text-blue-700',
+  commercial:    'bg-purple-100 text-purple-700',
+  transactional: 'bg-green-100 text-green-700',
+  navigational:  'bg-gray-100 text-gray-600',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  missing:   'bg-red-100 text-red-700',
+  draft:     'bg-yellow-100 text-yellow-700',
+  published: 'bg-green-100 text-green-700',
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function SupportingContentSection({
+  siteId,
+  pageId,
+}: SupportingContentSectionProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [data, setData] = useState<SupportingContentData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [generatingId, setGeneratingId] = useState<string | null>(null);
+  // Track optimistic status updates
+  const [optimisticStatus, setOptimisticStatus] = useState<Record<string, 'draft' | 'published'>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetchWithAuth(
+        `/api/v1/sites/${siteId}/pages/${pageId}/supporting-content/`
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setData(json);
+    } catch (e) {
+      console.error('[SupportingContentSection] fetch error:', e);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [siteId, pageId]);
+
+  useEffect(() => {
+    if (siteId && pageId) load();
+  }, [siteId, pageId, load]);
+
+  const handleGenerate = async (article: RecommendedArticle) => {
+    setGeneratingId(article.id);
+    try {
+      const res = await fetchWithAuth(
+        `/api/v1/sites/${siteId}/pages/${pageId}/supporting-content/generate/`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ article_id: article.id }),
+        }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      // Optimistic update
+      setOptimisticStatus(prev => ({ ...prev, [article.id]: 'draft' }));
+      toast({
+        title: '✅ Article generation started',
+        description: 'Check Content Hub for progress.',
+      });
+    } catch (e) {
+      console.error('[SupportingContentSection] generate error:', e);
+      toast({
+        title: '❌ Generation failed',
+        description: 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setGeneratingId(null);
+    }
+  };
+
+  const goToContentHub = () => {
+    router.push(`/dashboard?tab=content-hub&page_id=${pageId}`);
+  };
+
+  // ── Loading skeleton ───────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="mt-6 border-t border-slate-100 pt-5">
+        <div className="flex items-center gap-2 mb-4">
+          <div className="h-5 w-36 bg-slate-200 rounded animate-pulse" />
+          <div className="h-5 w-20 bg-slate-200 rounded-full animate-pulse" />
+        </div>
+        {[1, 2, 3].map(i => (
+          <div key={i} className="flex items-center gap-3 mb-3 p-3 bg-slate-50 rounded-lg animate-pulse">
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-3/4 bg-slate-200 rounded" />
+              <div className="h-3 w-1/2 bg-slate-200 rounded" />
+            </div>
+            <div className="h-8 w-28 bg-slate-200 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // ── Error state ────────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <div className="mt-6 border-t border-slate-100 pt-5">
+        <div className="flex items-center gap-2 text-slate-500 text-sm">
+          <AlertCircle size={16} className="text-amber-400" />
+          <span>Couldn&apos;t load supporting content recommendations.</span>
+          <button
+            onClick={load}
+            className="text-blue-600 hover:underline flex items-center gap-1"
+          >
+            <RefreshCw size={12} /> Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  // ── Empty state ────────────────────────────────────────────────────────────
+  if (data.gaps_detected === 0) {
+    return (
+      <div className="mt-6 border-t border-slate-100 pt-5">
+        <div className="flex items-center gap-2 mb-2">
+          <BookOpen size={16} className="text-slate-500" />
+          <h3 className="text-sm font-semibold text-slate-700">Supporting Content</h3>
+          <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-medium">
+            <CheckCircle size={11} /> Content complete
+          </span>
+        </div>
+        <p className="text-xs text-slate-500">
+          This page has all recommended supporting articles in place. Great Hub &amp; Spoke architecture!
+        </p>
+      </div>
+    );
+  }
+
+  // ── Main view ──────────────────────────────────────────────────────────────
+  return (
+    <div className="mt-6 border-t border-slate-100 pt-5">
+      {/* Section header */}
+      <div className="flex items-center gap-2 mb-3">
+        <BookOpen size={16} className="text-slate-500" />
+        <h3 className="text-sm font-semibold text-slate-700">Supporting Content</h3>
+        {data.gaps_detected > 0 && (
+          <span className="inline-flex items-center text-xs px-2 py-0.5 rounded-full bg-orange-100 text-orange-700 font-medium">
+            {data.gaps_detected} gap{data.gaps_detected !== 1 ? 's' : ''} detected
+          </span>
+        )}
+        <span
+          className="text-slate-400 cursor-help text-xs border border-slate-200 rounded-full w-4 h-4 flex items-center justify-center"
+          title="These are supporting articles that strengthen this page's authority in the Hub & Spoke architecture."
+        >
+          ?
+        </span>
+      </div>
+
+      {/* Article cards */}
+      <div className="space-y-2 mb-4">
+        {data.recommended_articles.map(article => {
+          const effectiveStatus = optimisticStatus[article.id] || article.status;
+          const isGenerating = generatingId === article.id;
+
+          return (
+            <div
+              key={article.id}
+              className="flex items-start gap-3 p-3 bg-slate-50 rounded-lg border border-slate-100 hover:border-slate-200 transition-colors"
+            >
+              {/* Article info */}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-slate-800 truncate">
+                  {article.suggested_title}
+                </p>
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  <span className="text-xs text-slate-400 font-mono truncate max-w-[180px]">
+                    {article.target_keyword}
+                  </span>
+                  {article.search_volume > 0 && (
+                    <span className="inline-flex items-center gap-0.5 text-xs text-slate-400">
+                      <TrendingUp size={10} />
+                      {article.search_volume.toLocaleString()}/mo
+                    </span>
+                  )}
+                  <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${INTENT_COLORS[article.intent] || 'bg-gray-100 text-gray-600'}`}>
+                    {article.intent}
+                  </span>
+                  <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${STATUS_COLORS[effectiveStatus] || 'bg-gray-100 text-gray-600'}`}>
+                    {effectiveStatus === 'missing' ? 'Missing' : effectiveStatus === 'draft' ? 'Draft' : 'Published'}
+                  </span>
+                </div>
+              </div>
+
+              {/* CTA button */}
+              <div className="flex-shrink-0">
+                {effectiveStatus === 'missing' && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="text-xs h-7 border-orange-300 text-orange-700 hover:bg-orange-50"
+                    onClick={() => handleGenerate(article)}
+                    disabled={isGenerating || !!generatingId}
+                  >
+                    {isGenerating ? (
+                      <><RefreshCw size={12} className="mr-1 animate-spin" /> Generating…</>
+                    ) : (
+                      <><Sparkles size={12} className="mr-1" /> Generate</>
+                    )}
+                  </Button>
+                )}
+                {(effectiveStatus === 'draft' || effectiveStatus === 'published') && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className={`text-xs h-7 ${effectiveStatus === 'published' ? 'border-green-300 text-green-700 hover:bg-green-50' : 'border-yellow-300 text-yellow-700 hover:bg-yellow-50'}`}
+                    onClick={goToContentHub}
+                  >
+                    View {effectiveStatus === 'published' ? 'Published' : 'Draft'}
+                  </Button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer CTA */}
+      <div className="flex items-center justify-between p-3 bg-blue-50 rounded-lg border border-blue-100">
+        <p className="text-xs text-blue-700">
+          This page needs <strong>{data.gaps_detected}</strong> supporting article{data.gaps_detected !== 1 ? 's' : ''} to complete its Hub &amp; Spoke architecture.
+        </p>
+        <Button
+          size="sm"
+          className="text-xs h-7 ml-3 flex-shrink-0 bg-blue-600 hover:bg-blue-700 text-white"
+          onClick={goToContentHub}
+        >
+          Go to Content Hub <ArrowRight size={12} className="ml-1" />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this does

Two major features added to the page analysis view — both built by Silas, just need merge.

### 1. Cannibalization Intelligence (NEW — CannibalizationIntelligence.tsx)
- **Informational Gain** score card: unique_percentage 0-100, colored by severity (green/amber/orange/red)
- **Geographic Grounding** score card: GBP signal checks for location pages
- Both auto-expand when status is weak/critical — users see problems immediately
- Green checkmarks for signals found, red X for signals missing
- 'How to Fix This' inline tips (static, hardcoded)
- Re-analyze prompt for pre-launch analyses without these fields
- GG section hidden for non-location pages automatically

### 2. Supporting Content CTA (SupportingContentSection.tsx)
- Surfaces Hub & Spoke content gaps directly in analysis view
- Article cards with Generate button → POST to generate endpoint
- 'Go to Content Hub →' deep link pre-filters to that page
- ContentHub reads ?page_id= from URL and auto-selects page

## Why it matters
AbleElectricKC.com has 13 near-identical city pages. The Cannibalization Intelligence section will show each one's IG score (expected ~15-30, Critical/Red) with the swap pattern warning. This is the demo moment that makes prospects pull out a credit card.

## Zero new API work
Both features render existing fields in the analysis response. No backend changes needed.

## Acceptance criteria
All 14 ACs from the IG/GG spec + all 12 ACs from the Supporting Content spec.
- [ ] IG score card renders with correct color and auto-expands on weak/critical
- [ ] GG section only shows for location pages
- [ ] Signals shown as checkmarks/X items
- [ ] Supporting content gaps appear below cannibalization section
- [ ] Generate button works with toast + optimistic update
- [ ] Content Hub deep link pre-selects page