### PR TITLE
fix: null guard on recommended_articles — prevents crash when API returns empty/null shape

### DIFF
--- a/components/screens/SupportingContentSection.tsx
+++ b/components/screens/SupportingContentSection.tsx
@@ -89,7 +89,7 @@ export default function SupportingContentSection({
       );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
-      setData(json);
+      setData({ ...json, recommended_articles: json.recommended_articles ?? [], gaps_detected: json.gaps_detected ?? 0 });
     } catch (e) {
       console.error('[SupportingContentSection] fetch error:', e);
       setError(true);
@@ -217,7 +217,7 @@ export default function SupportingContentSection({
 
       {/* Article cards */}
       <div className="space-y-2 mb-4">
-        {data.recommended_articles.map(article => {
+        {(data.recommended_articles ?? []).map(article => {
           const effectiveStatus = optimisticStatus[article.id] || article.status;
           const isGenerating = generatingId === article.id;
 


### PR DESCRIPTION
**Root cause:** When clicking 'Review Suggestions' on a page, `SupportingContentSection` fetches `/supporting-content/` and the API returns 200 but with `recommended_articles: null` or missing the field. Calling `.map()` on `null` throws `Cannot read properties of undefined (reading 'map')` which crashes the whole page.

**Fix:**
1. Normalize response on `setData`: `recommended_articles: json.recommended_articles ?? []`
2. Additional null guard on the `.map()` call itself as defense-in-depth

Two line change, no logic changes.