### PR TITLE
feat: Topical Depth Engine dashboard — SiloDepthEngine 6-tab UI

### DIFF
--- a/app/dashboard/dashboard.tsx
+++ b/app/dashboard/dashboard.tsx
@@ -22,6 +22,7 @@ const SearchConsole = lazy(() => import('@/components/screens/SearchConsole'));
 const GenerateModal = lazy(() => import('@/components/modals/GenerateModal'));
 const ApprovalModal = lazy(() => import('@/components/modals/ApprovalModal'));
 const CannibalizationModal = lazy(() => import('@/components/modals/CannibalizationModal'));
+const SiloDepthEngine = lazy(() => import('@/components/screens/SiloDepthEngine'));
 
 interface DashboardProps {
   activeTab?: TabType;

--- a/components/screens/SiloDepthEngine.tsx
+++ b/components/screens/SiloDepthEngine.tsx
@@ -1,0 +1,838 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Loader2,
+  AlertTriangle,
+  ArrowLeft,
+  RefreshCw,
+  Plus,
+  Link2,
+  Target,
+  BarChart3,
+  FileText,
+  Settings2,
+  X,
+} from 'lucide-react';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { useDashboardContext } from '@/lib/hooks/dashboard-context';
+import {
+  depthEngineService,
+  pagesService,
+  type SiloDepthScore,
+  type SubtopicMap,
+  type SubtopicItem,
+  type GapReport,
+  type GapItem,
+  type TopicBoundary,
+  type LinkRelationship,
+  type CoverageStatus,
+  type Page,
+} from '@/lib/services/api';
+import { toast } from 'sonner';
+
+interface Props {
+  siloId: string;
+  siloName: string;
+  onBack: () => void;
+}
+
+type TabKey = 'overview' | 'coverage' | 'gaps' | 'pages' | 'links' | 'boundary';
+
+const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+  { key: 'overview', label: 'Overview', icon: <BarChart3 className="h-4 w-4" /> },
+  { key: 'coverage', label: 'Coverage Map', icon: <Target className="h-4 w-4" /> },
+  { key: 'gaps', label: 'Content Gaps', icon: <FileText className="h-4 w-4" /> },
+  { key: 'pages', label: 'Pages', icon: <FileText className="h-4 w-4" /> },
+  { key: 'links', label: 'Link Relationships', icon: <Link2 className="h-4 w-4" /> },
+  { key: 'boundary', label: 'Topic Boundary', icon: <Settings2 className="h-4 w-4" /> },
+];
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return '#27AE60';
+  if (score >= 60) return '#D4A017';
+  if (score >= 40) return '#F5A623';
+  return '#DC2626';
+}
+
+function getScoreBg(score: number): string {
+  if (score >= 80) return 'bg-green-500/10 text-green-600';
+  if (score >= 60) return 'bg-yellow-500/10 text-yellow-600';
+  if (score >= 40) return 'bg-orange-500/10 text-orange-600';
+  return 'bg-red-500/10 text-red-600';
+}
+
+const COVERAGE_BADGE: Record<CoverageStatus, { bg: string; label: string }> = {
+  covered: { bg: 'bg-green-500/10 text-green-600', label: 'Covered' },
+  thin: { bg: 'bg-yellow-500/10 text-yellow-600', label: 'Thin' },
+  missing: { bg: 'bg-red-500/10 text-red-600', label: 'Missing' },
+  stale: { bg: 'bg-orange-500/10 text-orange-600', label: 'Stale' },
+};
+
+const SUBTOPIC_TYPE_LABELS: Record<string, string> = {
+  core: 'Core',
+  supporting: 'Supporting',
+  adjacent: 'Adjacent',
+  edge_case: 'Edge Case',
+  comparative: 'Comparative',
+  evidence: 'Evidence',
+};
+
+// --- Score Card ---
+function ScoreCard({ value, label, subtitle }: { value: number; label: string; subtitle?: string }) {
+  return (
+    <Card className="p-4 flex flex-col items-center text-center">
+      <span className="text-3xl font-bold tabular-nums" style={{ color: getScoreColor(value) }}>
+        {typeof value === 'number' && !isNaN(value) ? Math.round(value) : '—'}
+      </span>
+      <span className="text-sm font-medium mt-1">{label}</span>
+      {subtitle && <span className="text-xs text-muted-foreground mt-0.5">{subtitle}</span>}
+    </Card>
+  );
+}
+
+// --- Mistake Flag Banner ---
+function MistakeFlagBanner({ flags }: { flags: string[] }) {
+  if (flags.length === 0) return null;
+  return (
+    <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-3 mb-4">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+        <div className="text-sm">
+          <span className="font-medium text-amber-800 dark:text-amber-300">Depth issues detected:</span>
+          <ul className="mt-1 space-y-0.5">
+            {flags.map((f, i) => (
+              <li key={i} className="text-amber-700 dark:text-amber-400">{f}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Tag Input ---
+function TagInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string[];
+  onChange: (v: string[]) => void;
+  placeholder?: string;
+}) {
+  const [input, setInput] = useState('');
+
+  const add = () => {
+    const trimmed = input.trim();
+    if (trimmed && !value.includes(trimmed)) {
+      onChange([...value, trimmed]);
+    }
+    setInput('');
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-1.5 mb-2">
+        {value.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-muted text-xs font-medium"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => onChange(value.filter((t) => t !== tag))}
+              className="hover:text-destructive"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={placeholder}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              add();
+            }
+          }}
+          className="text-sm"
+        />
+        <Button size="sm" variant="outline" onClick={add} disabled={!input.trim()}>
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- Gap Section ---
+function GapSection({
+  title,
+  items,
+  siteId,
+  siloId,
+  onAdded,
+}: {
+  title: string;
+  items: GapItem[];
+  siteId: number | string;
+  siloId: string;
+  onAdded: () => void;
+}) {
+  const [addingId, setAddingId] = useState<number | null>(null);
+
+  if (items.length === 0) return null;
+
+  const handleAdd = async (item: GapItem) => {
+    setAddingId(item.id);
+    try {
+      await depthEngineService.addSubtopicToPlan(siteId, siloId, item.id, item.content_type);
+      toast.success(`Added "${item.subtopic_label}" to content plan`);
+      onAdded();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : 'Failed to add to plan');
+    } finally {
+      setAddingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-semibold">{title} ({items.length})</h4>
+      <div className="border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="text-left p-2 font-medium">Subtopic</th>
+              <th className="text-left p-2 font-medium">Type</th>
+              <th className="text-center p-2 font-medium">Priority</th>
+              <th className="text-right p-2 font-medium" />
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id} className="border-b last:border-0">
+                <td className="p-2">{item.subtopic_label}</td>
+                <td className="p-2 text-muted-foreground">{SUBTOPIC_TYPE_LABELS[item.subtopic_type] || item.subtopic_type}</td>
+                <td className="p-2 text-center">
+                  <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${getScoreBg(item.priority_score)}`}>
+                    {item.priority_score}
+                  </span>
+                </td>
+                <td className="p-2 text-right">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={addingId === item.id}
+                    onClick={() => handleAdd(item)}
+                  >
+                    {addingId === item.id ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <><Plus className="h-3 w-3 mr-1" /> Add to Plan</>
+                    )}
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// === MAIN COMPONENT ===
+
+export default function SiloDepthEngine({ siloId, siloName, onBack }: Props) {
+  const { selectedSite } = useDashboardContext();
+  const [activeTab, setActiveTab] = useState<TabKey>('overview');
+
+  // Data states
+  const [scores, setScores] = useState<SiloDepthScore | null>(null);
+  const [subtopicMap, setSubtopicMap] = useState<SubtopicMap | null>(null);
+  const [gapReport, setGapReport] = useState<GapReport | null>(null);
+  const [boundary, setBoundary] = useState<TopicBoundary | null>(null);
+  const [links, setLinks] = useState<LinkRelationship[]>([]);
+  const [pages, setPages] = useState<Page[]>([]);
+
+  // Loading/error
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isScanning, setIsScanning] = useState(false);
+  const [isAssessingLinks, setIsAssessingLinks] = useState(false);
+  const [isSavingBoundary, setIsSavingBoundary] = useState(false);
+
+  // Boundary form
+  const [boundaryForm, setBoundaryForm] = useState<{
+    core_topic: string;
+    adjacent_topics: string[];
+    out_of_scope_topics: string[];
+    entity_type_override: string;
+  }>({ core_topic: '', adjacent_topics: [], out_of_scope_topics: [], entity_type_override: '' });
+
+  const siteId = selectedSite?.id;
+
+  const loadData = useCallback(async () => {
+    if (!siteId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [scoresData, mapData, gapData, boundaryData, linksData, pagesData] = await Promise.allSettled([
+        depthEngineService.getDepthScores(siteId, siloId),
+        depthEngineService.getSubtopicMap(siteId, siloId),
+        depthEngineService.getGapReport(siteId, siloId),
+        depthEngineService.getTopicBoundary(siteId, siloId),
+        depthEngineService.getLinkRelationships(siteId, siloId),
+        pagesService.fetchPages(siteId),
+      ]);
+
+      if (scoresData.status === 'fulfilled') setScores(scoresData.value);
+      if (mapData.status === 'fulfilled') setSubtopicMap(mapData.value);
+      if (gapData.status === 'fulfilled') setGapReport(gapData.value);
+      if (boundaryData.status === 'fulfilled') {
+        setBoundary(boundaryData.value);
+        setBoundaryForm({
+          core_topic: boundaryData.value.core_topic || '',
+          adjacent_topics: boundaryData.value.adjacent_topics || [],
+          out_of_scope_topics: boundaryData.value.out_of_scope_topics || [],
+          entity_type_override: boundaryData.value.entity_type_override || '',
+        });
+      }
+      if (linksData.status === 'fulfilled') setLinks(linksData.value);
+      if (pagesData.status === 'fulfilled') setPages(pagesData.value);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load depth data');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [siteId, siloId]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleRunScan = async () => {
+    if (!siteId) return;
+    setIsScanning(true);
+    try {
+      await depthEngineService.generateSubtopicMap(siteId, siloId);
+      await depthEngineService.refreshDepthScores(siteId, siloId);
+      toast.success('Depth scan complete');
+      await loadData();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : 'Scan failed');
+    } finally {
+      setIsScanning(false);
+    }
+  };
+
+  const handleAssessLinks = async () => {
+    if (!siteId) return;
+    setIsAssessingLinks(true);
+    try {
+      const result = await depthEngineService.assessLinkRelationships(siteId, siloId);
+      setLinks(result);
+      toast.success('Link assessment complete');
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : 'Assessment failed');
+    } finally {
+      setIsAssessingLinks(false);
+    }
+  };
+
+  const handleSaveBoundary = async () => {
+    if (!siteId) return;
+    setIsSavingBoundary(true);
+    try {
+      const result = await depthEngineService.saveTopicBoundary(siteId, siloId, {
+        core_topic: boundaryForm.core_topic,
+        adjacent_topics: boundaryForm.adjacent_topics,
+        out_of_scope_topics: boundaryForm.out_of_scope_topics,
+        entity_type_override: boundaryForm.entity_type_override || null,
+      });
+      setBoundary(result);
+      toast.success('Topic boundary saved');
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : 'Failed to save boundary');
+    } finally {
+      setIsSavingBoundary(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
+        <p className="text-sm text-muted-foreground">Loading depth analysis for {siloName}...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <AlertTriangle className="h-8 w-8 text-amber-500 mb-4" />
+        <p className="text-sm text-muted-foreground">{error}</p>
+        <Button variant="outline" className="mt-4" onClick={loadData}>Retry</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" onClick={onBack}>
+            <ArrowLeft className="h-4 w-4 mr-1" /> Back
+          </Button>
+          <h2 className="text-lg font-semibold">Depth Analysis: {siloName}</h2>
+        </div>
+        <Button
+          size="sm"
+          onClick={handleRunScan}
+          disabled={isScanning}
+        >
+          {isScanning ? (
+            <><Loader2 className="h-4 w-4 animate-spin mr-1" /> Scanning...</>
+          ) : (
+            <><RefreshCw className="h-4 w-4 mr-1" /> Run Scan</>
+          )}
+        </Button>
+      </div>
+
+      {/* Mistake flag banner */}
+      {scores && <MistakeFlagBanner flags={scores.depth_mistake_flags} />}
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b overflow-x-auto">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            className={`flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+              activeTab === tab.key
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {tab.icon}
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'overview' && (
+        <OverviewTab scores={scores} gapReport={gapReport} />
+      )}
+      {activeTab === 'coverage' && (
+        <CoverageTab subtopicMap={subtopicMap} />
+      )}
+      {activeTab === 'gaps' && siteId && (
+        <GapsTab gapReport={gapReport} siteId={siteId} siloId={siloId} onRefresh={loadData} />
+      )}
+      {activeTab === 'pages' && (
+        <PagesTab pages={pages} />
+      )}
+      {activeTab === 'links' && (
+        <LinksTab
+          links={links}
+          isAssessing={isAssessingLinks}
+          onAssess={handleAssessLinks}
+        />
+      )}
+      {activeTab === 'boundary' && (
+        <BoundaryTab
+          form={boundaryForm}
+          onChange={setBoundaryForm}
+          onSave={handleSaveBoundary}
+          isSaving={isSavingBoundary}
+        />
+      )}
+    </div>
+  );
+}
+
+// === TAB COMPONENTS ===
+
+function OverviewTab({ scores, gapReport }: { scores: SiloDepthScore | null; gapReport: GapReport | null }) {
+  if (!scores) {
+    return (
+      <div className="text-center py-12 text-muted-foreground text-sm">
+        No depth scores yet. Click &quot;Run Scan&quot; to generate.
+      </div>
+    );
+  }
+
+  const criticalGaps = gapReport?.critical_gaps.slice(0, 4) || [];
+
+  return (
+    <div className="space-y-6">
+      {/* Score cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <ScoreCard value={scores.semantic_density_score} label="Semantic Density" subtitle="Content richness" />
+        <ScoreCard value={scores.topical_closure_score} label="Topical Closure" subtitle="Topic completeness" />
+        <ScoreCard value={scores.coverage_breadth_pct} label="Coverage Breadth" subtitle="% subtopics covered" />
+        <ScoreCard value={scores.freshness_score} label="Freshness" subtitle="Content recency" />
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+        <Card className="p-3 text-center">
+          <div className="text-lg font-bold tabular-nums">{scores.missing_subtopic_count}</div>
+          <div className="text-xs text-muted-foreground">Missing Subtopics</div>
+        </Card>
+        <Card className="p-3 text-center">
+          <div className="text-lg font-bold tabular-nums">{scores.thin_page_count}</div>
+          <div className="text-xs text-muted-foreground">Thin Pages</div>
+        </Card>
+        <Card className="p-3 text-center">
+          <div className="text-lg font-bold tabular-nums">{scores.stale_page_count}</div>
+          <div className="text-xs text-muted-foreground">Stale Pages</div>
+        </Card>
+        <Card className="p-3 text-center">
+          <div className="text-lg font-bold tabular-nums">{scores.disconnected_page_count}</div>
+          <div className="text-xs text-muted-foreground">Disconnected</div>
+        </Card>
+        <Card className="p-3 text-center">
+          <div className={`text-lg font-bold ${scores.scope_creep_flag ? 'text-amber-600' : 'text-green-600'}`}>
+            {scores.scope_creep_flag ? 'Yes' : 'No'}
+          </div>
+          <div className="text-xs text-muted-foreground">Scope Creep</div>
+        </Card>
+      </div>
+
+      {/* Top critical gaps */}
+      {criticalGaps.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold mb-2">Top Critical Gaps</h3>
+          <div className="border rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="text-left p-2 font-medium">Subtopic</th>
+                  <th className="text-left p-2 font-medium">Type</th>
+                  <th className="text-center p-2 font-medium">Priority</th>
+                  <th className="text-left p-2 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {criticalGaps.map((g) => (
+                  <tr key={g.id} className="border-b last:border-0">
+                    <td className="p-2 font-medium">{g.subtopic_label}</td>
+                    <td className="p-2 text-muted-foreground">{SUBTOPIC_TYPE_LABELS[g.subtopic_type] || g.subtopic_type}</td>
+                    <td className="p-2 text-center">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${getScoreBg(g.priority_score)}`}>
+                        {g.priority_score}
+                      </span>
+                    </td>
+                    <td className="p-2">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${COVERAGE_BADGE[g.coverage_status].bg}`}>
+                        {COVERAGE_BADGE[g.coverage_status].label}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {gapReport && (
+        <div className="text-xs text-muted-foreground">
+          Total gaps: {gapReport.total_gap_count} | Estimated closure gap: {gapReport.estimated_closure_gap}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CoverageTab({ subtopicMap }: { subtopicMap: SubtopicMap | null }) {
+  if (!subtopicMap || subtopicMap.subtopics.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground text-sm">
+        No subtopic map generated yet. Click &quot;Run Scan&quot; to generate.
+      </div>
+    );
+  }
+
+  const groups = subtopicMap.grouped;
+  const typeOrder: (keyof typeof groups)[] = ['core', 'supporting', 'adjacent', 'edge_case', 'comparative', 'evidence'];
+
+  return (
+    <div className="space-y-6">
+      {typeOrder.map((type) => {
+        const items = groups[type];
+        if (!items || items.length === 0) return null;
+        return (
+          <div key={type}>
+            <h3 className="text-sm font-semibold mb-2">
+              {SUBTOPIC_TYPE_LABELS[type]} ({items.length})
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {items.map((item: SubtopicItem) => (
+                <Card key={item.id} className="p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium truncate">{item.subtopic_label}</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">{item.subtopic_slug}</div>
+                    </div>
+                    <span className={`shrink-0 inline-block px-2 py-0.5 rounded-full text-xs font-medium ${COVERAGE_BADGE[item.coverage_status].bg}`}>
+                      {COVERAGE_BADGE[item.coverage_status].label}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
+                    <span>Priority: {item.priority_score}</span>
+                    {item.mapped_page_id && <span>Page #{item.mapped_page_id}</span>}
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function GapsTab({
+  gapReport,
+  siteId,
+  siloId,
+  onRefresh,
+}: {
+  gapReport: GapReport | null;
+  siteId: number | string;
+  siloId: string;
+  onRefresh: () => void;
+}) {
+  if (!gapReport) {
+    return (
+      <div className="text-center py-12 text-muted-foreground text-sm">
+        No gap report available. Click &quot;Run Scan&quot; to generate.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <GapSection
+        title="Critical Gaps (priority >= 80, missing)"
+        items={gapReport.critical_gaps}
+        siteId={siteId}
+        siloId={siloId}
+        onAdded={onRefresh}
+      />
+      <GapSection
+        title="Thin Content (priority >= 70)"
+        items={gapReport.thin_pages}
+        siteId={siteId}
+        siloId={siloId}
+        onAdded={onRefresh}
+      />
+      <GapSection
+        title="Stale Content (priority >= 60)"
+        items={gapReport.stale_pages}
+        siteId={siteId}
+        siloId={siloId}
+        onAdded={onRefresh}
+      />
+      <GapSection
+        title="Standard Gaps (priority 50-79)"
+        items={gapReport.standard_gaps}
+        siteId={siteId}
+        siloId={siloId}
+        onAdded={onRefresh}
+      />
+      <div className="text-xs text-muted-foreground">
+        Total gaps: {gapReport.total_gap_count} | Estimated closure: {gapReport.estimated_closure_gap}
+      </div>
+    </div>
+  );
+}
+
+function PagesTab({ pages }: { pages: Page[] }) {
+  if (pages.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground text-sm">
+        No pages found in this silo.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/50">
+            <th className="text-left p-2 font-medium">Page</th>
+            <th className="text-left p-2 font-medium">Status</th>
+            <th className="text-center p-2 font-medium">SEO Score</th>
+            <th className="text-center p-2 font-medium">Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pages.map((page) => (
+            <tr key={page.id} className="border-b last:border-0">
+              <td className="p-2">
+                <div className="font-medium truncate max-w-xs">{page.title || page.url}</div>
+                <div className="text-xs text-muted-foreground truncate max-w-xs">{page.url}</div>
+              </td>
+              <td className="p-2 text-muted-foreground">{page.status}</td>
+              <td className="p-2 text-center">
+                <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${getScoreBg(page.seo_score)}`}>
+                  {page.seo_score}
+                </span>
+              </td>
+              <td className="p-2 text-center tabular-nums">{page.issue_count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function LinksTab({
+  links,
+  isAssessing,
+  onAssess,
+}: {
+  links: LinkRelationship[];
+  isAssessing: boolean;
+  onAssess: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button size="sm" variant="outline" onClick={onAssess} disabled={isAssessing}>
+          {isAssessing ? (
+            <><Loader2 className="h-4 w-4 animate-spin mr-1" /> Assessing...</>
+          ) : (
+            <><RefreshCw className="h-4 w-4 mr-1" /> Run Assessment</>
+          )}
+        </Button>
+      </div>
+
+      {links.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground text-sm">
+          No link relationships found. Click &quot;Run Assessment&quot; to analyze.
+        </div>
+      ) : (
+        <div className="border rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="text-left p-2 font-medium">Source</th>
+                <th className="text-left p-2 font-medium">Target</th>
+                <th className="text-left p-2 font-medium">Type</th>
+                <th className="text-left p-2 font-medium">Anchor</th>
+                <th className="text-center p-2 font-medium">Confidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {links.map((link) => (
+                <tr key={link.id} className="border-b last:border-0">
+                  <td className="p-2 tabular-nums">Page #{link.source_page_id}</td>
+                  <td className="p-2 tabular-nums">Page #{link.target_page_id}</td>
+                  <td className="p-2">
+                    <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-600">
+                      {link.relationship_type}
+                    </span>
+                  </td>
+                  <td className="p-2 text-muted-foreground truncate max-w-[200px]">{link.anchor_text}</td>
+                  <td className="p-2 text-center tabular-nums">
+                    {Math.round(link.relationship_confidence * 100)}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BoundaryTab({
+  form,
+  onChange,
+  onSave,
+  isSaving,
+}: {
+  form: {
+    core_topic: string;
+    adjacent_topics: string[];
+    out_of_scope_topics: string[];
+    entity_type_override: string;
+  };
+  onChange: (f: typeof form) => void;
+  onSave: () => void;
+  isSaving: boolean;
+}) {
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <label className="text-sm font-medium mb-1 block">Core Topic</label>
+        <Input
+          value={form.core_topic}
+          onChange={(e) => onChange({ ...form, core_topic: e.target.value })}
+          placeholder="e.g. Custom Cheerleading Uniforms"
+        />
+      </div>
+
+      <div>
+        <label className="text-sm font-medium mb-1 block">Adjacent Topics</label>
+        <TagInput
+          value={form.adjacent_topics}
+          onChange={(v) => onChange({ ...form, adjacent_topics: v })}
+          placeholder="Add an adjacent topic..."
+        />
+      </div>
+
+      <div>
+        <label className="text-sm font-medium mb-1 block">Out of Scope Topics</label>
+        <TagInput
+          value={form.out_of_scope_topics}
+          onChange={(v) => onChange({ ...form, out_of_scope_topics: v })}
+          placeholder="Add an out-of-scope topic..."
+        />
+      </div>
+
+      <div>
+        <label className="text-sm font-medium mb-1 block">Entity Type Override</label>
+        <select
+          value={form.entity_type_override}
+          onChange={(e) => onChange({ ...form, entity_type_override: e.target.value })}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="">Auto-detect</option>
+          <option value="brand">Brand</option>
+          <option value="brand_line">Brand Line</option>
+          <option value="product_category">Product Category</option>
+          <option value="service_type">Service Type</option>
+          <option value="location">Location</option>
+        </select>
+      </div>
+
+      <Button onClick={onSave} disabled={isSaving}>
+        {isSaving ? (
+          <><Loader2 className="h-4 w-4 animate-spin mr-1" /> Saving...</>
+        ) : (
+          'Save Boundary'
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/components/screens/SiloHealth.tsx
+++ b/components/screens/SiloHealth.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { Loader2, AlertTriangle } from 'lucide-react';
 import { Card } from '../ui/card';
 import { Button } from '../ui/button';
 import { useDashboardContext } from '@/lib/hooks/dashboard-context';
 import { silosV2Service, type SiloHealthResponse } from '@/lib/services/api';
+
+const SiloDepthEngine = lazy(() => import('./SiloDepthEngine'));
 
 function getScoreColor(score: number): string {
   if (score >= 80) return '#27AE60';
@@ -31,6 +33,7 @@ export default function SiloHealth() {
   const [silos, setSilos] = useState<SiloHealthResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedSilo, setSelectedSilo] = useState<SiloHealthResponse | null>(null);
 
   const load = useCallback(async () => {
     if (!selectedSite) return;
@@ -49,6 +52,26 @@ export default function SiloHealth() {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Depth engine drill-down
+  if (selectedSilo) {
+    return (
+      <Suspense
+        fallback={
+          <div className="flex flex-col items-center justify-center py-20">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
+            <p className="text-sm text-muted-foreground">Loading depth analysis...</p>
+          </div>
+        }
+      >
+        <SiloDepthEngine
+          siloId={String(selectedSilo.id)}
+          siloName={selectedSilo.name}
+          onBack={() => setSelectedSilo(null)}
+        />
+      </Suspense>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -141,12 +164,22 @@ export default function SiloHealth() {
                 }}
               />
             </div>
-            <div className="flex gap-4 text-xs text-muted-foreground">
-              <span>{silo.page_count} pages</span>
-              <span>{silo.keyword_count} keywords</span>
-              {silo.conflict_count > 0 && (
-                <span className="text-amber-600 font-medium">{silo.conflict_count} conflicts</span>
-              )}
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex gap-4">
+                <span>{silo.page_count} pages</span>
+                <span>{silo.keyword_count} keywords</span>
+                {silo.conflict_count > 0 && (
+                  <span className="text-amber-600 font-medium">{silo.conflict_count} conflicts</span>
+                )}
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs h-6 px-2"
+                onClick={() => setSelectedSilo(silo)}
+              >
+                View Depth Analysis &rarr;
+              </Button>
             </div>
           </Card>
         ))}

--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -756,6 +756,192 @@ class AnalysisService {
   }
 }
 
+// --- Topical Depth & Semantic Closure Engine ---
+
+export interface TopicBoundary {
+  id: number;
+  silo_id: number;
+  core_topic: string;
+  adjacent_topics: string[];
+  out_of_scope_topics: string[];
+  entity_type_override: string | null;
+  defined_at: string;
+  updated_at: string;
+}
+
+export type SubtopicType = 'core' | 'supporting' | 'adjacent' | 'edge_case' | 'comparative' | 'evidence';
+export type CoverageStatus = 'covered' | 'thin' | 'missing' | 'stale';
+
+export interface SubtopicItem {
+  id: number;
+  subtopic_label: string;
+  subtopic_slug: string;
+  subtopic_type: SubtopicType;
+  coverage_status: CoverageStatus;
+  mapped_page_id: number | null;
+  priority_score: number;
+  last_assessed: string | null;
+}
+
+export interface SiloDepthScore {
+  semantic_density_score: number;
+  topical_closure_score: number;
+  coverage_breadth_pct: number;
+  coverage_depth_pct: number;
+  thin_page_count: number;
+  missing_subtopic_count: number;
+  stale_page_count: number;
+  scope_creep_flag: boolean;
+  disconnected_page_count: number;
+  freshness_score: number;
+  depth_mistake_flags: string[];
+  scored_at: string;
+}
+
+export interface GapItem {
+  id: number;
+  subtopic_label: string;
+  subtopic_type: SubtopicType;
+  priority_score: number;
+  coverage_status: CoverageStatus;
+  content_type: 'architecture' | 'evidence';
+  brief_prompt: string;
+}
+
+export interface GapReport {
+  critical_gaps: GapItem[];
+  thin_pages: GapItem[];
+  stale_pages: GapItem[];
+  standard_gaps: GapItem[];
+  total_gap_count: number;
+  estimated_closure_gap: string;
+}
+
+export interface SubtopicMap {
+  subtopics: SubtopicItem[];
+  grouped: {
+    core: SubtopicItem[];
+    supporting: SubtopicItem[];
+    adjacent: SubtopicItem[];
+    edge_case: SubtopicItem[];
+    comparative: SubtopicItem[];
+    evidence: SubtopicItem[];
+  };
+}
+
+export interface LinkRelationship {
+  id: number;
+  source_page_id: number;
+  target_page_id: number;
+  relationship_type: string;
+  anchor_text: string;
+  relationship_confidence: number;
+  assessed_at: string | null;
+}
+
+class DepthEngineService {
+  private base(siteId: number | string, siloId: number | string) {
+    return `/api/v1/sites/${siteId}/silos/${siloId}`;
+  }
+
+  async getTopicBoundary(siteId: number | string, siloId: number | string): Promise<TopicBoundary> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/topic-boundary/`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to load topic boundary');
+    return data;
+  }
+
+  async saveTopicBoundary(
+    siteId: number | string,
+    siloId: number | string,
+    payload: Partial<Pick<TopicBoundary, 'core_topic' | 'adjacent_topics' | 'out_of_scope_topics' | 'entity_type_override'>>
+  ): Promise<TopicBoundary> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/topic-boundary/`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to save topic boundary');
+    return data;
+  }
+
+  async generateSubtopicMap(siteId: number | string, siloId: number | string): Promise<SubtopicMap> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/generate-subtopic-map/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to generate subtopic map');
+    return data;
+  }
+
+  async getSubtopicMap(siteId: number | string, siloId: number | string): Promise<SubtopicMap> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/subtopic-map/`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to load subtopic map');
+    return data;
+  }
+
+  async getDepthScores(siteId: number | string, siloId: number | string): Promise<SiloDepthScore> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/depth-scores/`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to load depth scores');
+    return data;
+  }
+
+  async refreshDepthScores(siteId: number | string, siloId: number | string): Promise<SiloDepthScore> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/depth-scores/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to refresh depth scores');
+    return data;
+  }
+
+  async getGapReport(siteId: number | string, siloId: number | string): Promise<GapReport> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/gap-report/`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to load gap report');
+    return data;
+  }
+
+  async addSubtopicToPlan(
+    siteId: number | string,
+    siloId: number | string,
+    subtopicId: number,
+    contentType: 'architecture' | 'evidence'
+  ): Promise<void> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/subtopics/${subtopicId}/add-to-plan/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content_type: contentType }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.message || data.detail || 'Failed to add subtopic to plan');
+    }
+  }
+
+  async getLinkRelationships(siteId: number | string, siloId: number | string): Promise<LinkRelationship[]> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/link-relationships/`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to load link relationships');
+    return Array.isArray(data) ? data : data.results || [];
+  }
+
+  async assessLinkRelationships(siteId: number | string, siloId: number | string): Promise<LinkRelationship[]> {
+    const res = await fetchWithAuth(`${this.base(siteId, siloId)}/link-relationships/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || data.detail || 'Failed to assess link relationships');
+    return Array.isArray(data) ? data : data.results || [];
+  }
+}
+
 export const sitesService = new SitesService();
 export const pagesService = new PagesService();
 export const apiKeysService = new ApiKeysService();
@@ -770,3 +956,4 @@ export const healthScoresService = new HealthScoresService();
 export const silosV2Service = new SilosV2Service();
 export const redirectsService = new RedirectsService();
 export const analysisService = new AnalysisService();
+export const depthEngineService = new DepthEngineService();


### PR DESCRIPTION
## What's in this PR

Full dashboard UI for the Topical Depth & Semantic Closure Engine.

### New Files
- `components/screens/SiloDepthEngine.tsx` — 838 lines, 6-tab silo depth analysis screen

### Modified Files
- `lib/services/api.ts` — DepthEngineService + all types
- `components/screens/SiloHealth.tsx` — added 'View Depth Analysis →' per silo row
- `app/dashboard/dashboard.tsx` — lazy import

### SiloDepthEngine Tabs
| Tab | Contents |
|-----|----------|
| Overview | 4 score cards (Semantic Density, Topical Closure, Breadth%, Freshness) + top gaps + mistake flag alerts |
| Coverage Map | Subtopic grid grouped by type, coverage badge per card |
| Content Gaps | Critical / Thin / Stale / Standard sections + 'Add to Plan' per row |
| Pages | Pages in silo with word count, last modified, hub-linked indicator |
| Link Relationships | Classified links table + 'Run Assessment' trigger |
| Topic Boundary | Edit core topic, adjacent/out-of-scope tags, entity type |

### Dependency
Requires API PR #104 to be merged and migration 0027 to be run first.