### PR TITLE
feat: onboarding checklist, empty states, clearer tab labels, site selector status

### DIFF
--- a/app/dashboard/dashboard.tsx
+++ b/app/dashboard/dashboard.tsx
@@ -30,6 +30,7 @@ const ApprovalModal = lazy(() => import('@/components/modals/ApprovalModal'));
 const CannibalizationModal = lazy(() => import('@/components/modals/CannibalizationModal'));
 const SiloDepthEngine = lazy(() => import('@/components/screens/SiloDepthEngine'));
 const TeamAuthorsTab = lazy(() => import('@/components/screens/TeamAuthorsTab'));
+const SiteIntelligencePanel = lazy(() => import('@/components/screens/SiteIntelligencePanel'));
 
 interface DashboardProps {
   activeTab?: TabType;
@@ -226,6 +227,12 @@ export default function Dashboard({
         return <Settings onNavigateToSites={() => onTabChange?.('sites')} currentTier={userTier as any} />;
       case 'team-authors':
         return <TeamAuthorsTab />;
+      case 'intelligence':
+        return selectedSite ? <SiteIntelligencePanel siteId={selectedSite.id} /> : null;
+      case 'silo-health':
+        return <SiloHealth />;
+      case 'performance':
+        return <SearchConsole selectedSite={selectedSite} />;
       default:
         return null;
     }

--- a/app/dashboard/header.tsx
+++ b/app/dashboard/header.tsx
@@ -162,7 +162,17 @@ export default function Header({
             onClick={() => setShowSiteDropdown(!showSiteDropdown)}
             className="flex items-center gap-2 rounded-lg border bg-background px-3 py-1.5 text-sm transition-colors hover:bg-muted"
           >
-            <Globe className="h-3.5 w-3.5 text-gray-700 dark:text-gray-300" />
+            {selectedSite ? (
+              <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+                (selectedSite.page_count ?? 0) > 0 && selectedSite.gsc_connected
+                  ? 'bg-green-500'
+                  : (selectedSite.page_count ?? 0) > 0
+                  ? 'bg-yellow-500'
+                  : 'bg-red-500'
+              }`} />
+            ) : (
+              <Globe className="h-3.5 w-3.5 text-gray-700 dark:text-gray-300" />
+            )}
             <span className="max-w-[150px] truncate text-gray-700 dark:text-gray-300 sm:max-w-[200px]">
               {selectedSite?.name || 'Select a site'}
             </span>
@@ -170,39 +180,55 @@ export default function Header({
           </button>
 
           {showSiteDropdown && (
-            <div className="absolute right-0 top-full z-50 mt-2 w-64 rounded-xl border bg-white p-2 shadow-2xl dark:bg-slate-900">
+            <div className="absolute right-0 top-full z-50 mt-2 w-72 rounded-xl border bg-white p-2 shadow-2xl dark:bg-slate-900">
               {sites.length === 0 ? (
                 <div className="px-3 py-2 text-sm text-muted-foreground">
                   No sites available
                 </div>
               ) : (
-                sites.map((site) => (
-                  <button
-                    key={site.id}
-                    onClick={() => {
-                      selectSite(site);
-                      setShowSiteDropdown(false);
-                    }}
-                    className={cn(
-                      'flex w-full items-center justify-between rounded-lg px-3 py-2 text-left transition-colors',
-                      selectedSite?.id === site.id
-                        ? 'bg-primary/10'
-                        : 'hover:bg-muted'
-                    )}
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium text-slate-700 dark:text-slate-300 truncate">
-                        {site.name}
+                sites.map((site) => {
+                  const hasPages = (site.page_count ?? 0) > 0;
+                  const hasGsc = !!site.gsc_connected;
+                  const statusColor = hasPages && hasGsc
+                    ? 'bg-green-500'
+                    : hasPages
+                    ? 'bg-yellow-500'
+                    : 'bg-red-500';
+                  const statusLabel = hasPages && hasGsc
+                    ? 'Fully set up'
+                    : hasPages
+                    ? 'Partially set up'
+                    : 'Needs attention';
+
+                  return (
+                    <button
+                      key={site.id}
+                      onClick={() => {
+                        selectSite(site);
+                        setShowSiteDropdown(false);
+                      }}
+                      className={cn(
+                        'flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors',
+                        selectedSite?.id === site.id
+                          ? 'bg-primary/10'
+                          : 'hover:bg-muted'
+                      )}
+                    >
+                      <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${statusColor}`} title={statusLabel} />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-semibold text-slate-700 dark:text-slate-300 truncate">
+                          {site.name}
+                        </div>
+                        <div className="text-xs text-slate-400 dark:text-slate-500 truncate">
+                          {site.url}
+                        </div>
                       </div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400 truncate">
-                        {site.url}
-                      </div>
-                    </div>
-                    {selectedSite?.id === site.id && (
-                      <Check className="ml-2 h-4 w-4 flex-shrink-0 text-primary" />
-                    )}
-                  </button>
-                ))
+                      {selectedSite?.id === site.id && (
+                        <Check className="ml-2 h-4 w-4 flex-shrink-0 text-primary" />
+                      )}
+                    </button>
+                  );
+                })
               )}
             </div>
           )}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,13 +13,11 @@ const TAB_REDIRECTS: Record<string, string> = {
   'overview': 'dashboard',
   'silos': 'dashboard',
   'keyword-registry': 'conflicts',
-  'silo-health': 'dashboard',
   'content-hub': 'pages',
   'content-upload': 'pages',
   'content': 'pages',
   'internal-links': 'pages',
   'all-sites': 'sites',
-  'performance': 'search-console',
 };
 
 function DashboardContent() {

--- a/app/dashboard/types.ts
+++ b/app/dashboard/types.ts
@@ -17,7 +17,9 @@ export type TabType =
   | 'content-plan'
   | 'schema'
   | 'freshness'
-  | 'team-authors';
+  | 'team-authors'
+  | 'intelligence'
+  | 'performance';
 export type AutomationMode = 'manual' | 'semi' | 'full';
 
 export interface ConflictPage {

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -18,6 +18,8 @@ import {
   BookOpen,
   Map,
   Users,
+  Brain,
+  Layers,
 } from 'lucide-react';
 
 import { NavUser } from '@/components/nav-user';
@@ -36,48 +38,69 @@ import {
 const navMain = [
   {
     title: 'Dashboard',
-    url: '/dashboard?tab=overview',
+    url: '/dashboard?tab=dashboard',
     icon: LayoutDashboard,
+    description: 'Overview & priorities',
   },
   {
     title: 'Sites',
     url: '/dashboard?tab=sites',
     icon: Globe,
+    description: 'Manage your websites',
+  },
+  {
+    title: 'SEO Plan',
+    url: '/dashboard?tab=intelligence',
+    icon: Brain,
+    description: 'Prioritized action list',
   },
   {
     title: 'Conflicts',
     url: '/dashboard?tab=conflicts',
     icon: Shield,
+    description: 'Keyword cannibalization',
   },
   {
     title: 'Pages',
     url: '/dashboard?tab=pages',
     icon: FileText,
+    description: 'Page management',
+  },
+  {
+    title: 'Content Depth',
+    url: '/dashboard?tab=silo-health',
+    icon: Layers,
+    description: 'Find topic gaps',
   },
   {
     title: 'Content Plan',
     url: '/dashboard?tab=content-plan',
     icon: BookOpen,
+    description: 'AI blog generation',
   },
   {
     title: 'Team & Authors',
     url: '/dashboard?tab=team-authors',
     icon: Users,
+    description: 'E-E-A-T signals',
   },
   {
-    title: 'Performance',
-    url: '/dashboard?tab=performance',
+    title: 'Search Console',
+    url: '/dashboard?tab=search-console',
     icon: Activity,
+    description: 'GSC performance data',
   },
   {
     title: 'Approvals',
     url: '/dashboard?tab=approvals',
     icon: CheckSquare,
+    description: 'Review pending changes',
   },
   {
     title: 'Settings',
     url: '/dashboard?tab=settings',
     icon: Settings,
+    description: 'Site configuration',
   },
 ];
 
@@ -182,13 +205,22 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       href={item.url}
                       className="flex items-center gap-2 font-medium"
                     >
-                      <item.icon className="size-4" />
-                      {item.title}
-                      {isContentPlan && gapsCount > 0 && (
-                        <span className="ml-auto bg-amber-100 text-amber-700 text-xs px-1.5 py-0.5 rounded-full">
-                          {gapsCount}
-                        </span>
-                      )}
+                      <item.icon className="size-4 shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate">{item.title}</span>
+                          {isContentPlan && gapsCount > 0 && (
+                            <span className="ml-auto bg-amber-100 text-amber-700 text-xs px-1.5 py-0.5 rounded-full shrink-0">
+                              {gapsCount}
+                            </span>
+                          )}
+                        </div>
+                        {item.description && (
+                          <span className="text-[10px] text-muted-foreground leading-none truncate block">
+                            {item.description}
+                          </span>
+                        )}
+                      </div>
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/components/screens/ContentPlanTab.tsx
+++ b/components/screens/ContentPlanTab.tsx
@@ -767,9 +767,9 @@ export default function ContentPlanTab() {
             </svg>
           </div>
           <div>
-            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-200">No topics yet</h3>
+            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-200">No content topics yet</h3>
             <p className="text-sm text-slate-500 mt-1 max-w-md">
-              Click &quot;Generate Topics&quot; to run keyword discovery and create a content plan for your site.
+              Click &quot;Generate Topics&quot; to create your content plan based on keyword research.
             </p>
           </div>
           <button

--- a/components/screens/DashboardHome.tsx
+++ b/components/screens/DashboardHome.tsx
@@ -20,6 +20,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import type { TabType } from '@/app/dashboard/types';
+import { useDashboardContext } from '@/lib/hooks/dashboard-context';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -240,6 +241,92 @@ function EmptyColumn({ icon, message }: { icon: React.ReactNode; message: string
   );
 }
 
+// ─── Onboarding Checklist ─────────────────────────────────────────────────────
+
+interface OnboardingStep {
+  id: string;
+  label: string;
+  done: boolean;
+  tab: TabType;
+}
+
+function OnboardingChecklist({ steps, onNavigate }: { steps: OnboardingStep[]; onNavigate: (tab: TabType) => void }) {
+  const completedCount = steps.filter(s => s.done).length;
+  const totalCount = steps.length;
+  const allDone = completedCount === totalCount;
+  if (allDone) return null;
+
+  const progressPct = Math.round((completedCount / totalCount) * 100);
+  const nextStep = steps.find(s => !s.done);
+
+  return (
+    <Card className="border border-blue-200 bg-gradient-to-r from-blue-50 to-white rounded-xl overflow-hidden">
+      <CardContent className="p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-900">Get started with Siloq</h2>
+            <p className="text-xs text-slate-500 mt-0.5">{completedCount} of {totalCount} steps complete</p>
+          </div>
+          <span className="text-sm font-bold text-blue-600">{progressPct}%</span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="w-full bg-slate-100 rounded-full h-2 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-blue-500 transition-all"
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+
+        {/* Steps */}
+        <div className="space-y-2">
+          {steps.map(step => (
+            <button
+              key={step.id}
+              onClick={() => !step.done && onNavigate(step.tab)}
+              className={`flex items-center gap-3 w-full text-left px-3 py-2 rounded-lg transition-colors ${
+                step.done
+                  ? 'bg-green-50 cursor-default'
+                  : 'hover:bg-blue-50 cursor-pointer'
+              }`}
+            >
+              <span className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs ${
+                step.done
+                  ? 'bg-green-500 text-white'
+                  : 'border-2 border-slate-300 text-transparent'
+              }`}>
+                {step.done && (
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </span>
+              <span className={`text-sm ${step.done ? 'text-slate-400 line-through' : 'text-slate-700 font-medium'}`}>
+                {step.label}
+              </span>
+              {!step.done && (
+                <ArrowRight className="w-3.5 h-3.5 text-slate-400 ml-auto" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* Next step CTA */}
+        {nextStep && (
+          <Button
+            size="sm"
+            className="w-full gap-1.5 text-xs bg-blue-600 hover:bg-blue-700 text-white"
+            onClick={() => onNavigate(nextStep.tab)}
+          >
+            Next step: {nextStep.label}
+            <ArrowRight className="w-3.5 h-3.5" />
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── Main Component ────────────────────────────────────────────────────────────
 
 interface DashboardHomeProps {
@@ -248,6 +335,7 @@ interface DashboardHomeProps {
 }
 
 export default function DashboardHome({ siteId, onNavigate }: DashboardHomeProps) {
+  const { selectedSite } = useDashboardContext();
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [usingMock, setUsingMock] = useState(false);
@@ -294,8 +382,24 @@ export default function DashboardHome({ siteId, onNavigate }: DashboardHomeProps
 
   const { stats, fix_now, in_progress, done_this_month } = data;
 
+  // Onboarding checklist steps
+  const hasServices = !!(selectedSite as any)?.primary_services?.length;
+  const hasRunAnalysis = stats.pages_optimized > 0 || fix_now.length > 0;
+  const onboardingSteps: OnboardingStep[] = selectedSite ? [
+    { id: 'pages', label: 'Sync your pages', done: (selectedSite.page_count ?? 0) > 0, tab: 'sites' },
+    { id: 'services', label: 'Add your services', done: hasServices, tab: 'settings' },
+    { id: 'gsc', label: 'Connect Google Search Console', done: !!selectedSite.gsc_connected, tab: 'search-console' },
+    { id: 'analysis', label: 'Run your first SEO analysis', done: hasRunAnalysis, tab: 'intelligence' },
+  ] : [];
+  const showChecklist = selectedSite && onboardingSteps.some(s => !s.done);
+
   return (
     <div className="space-y-6">
+      {/* ── Onboarding Checklist ── */}
+      {showChecklist && (
+        <OnboardingChecklist steps={onboardingSteps} onNavigate={onNavigate} />
+      )}
+
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>

--- a/components/screens/SiloHealth.tsx
+++ b/components/screens/SiloHealth.tsx
@@ -96,9 +96,9 @@ export default function SiloHealth() {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <span className="text-4xl mb-4">📊</span>
-        <h3 className="text-lg font-semibold mb-2">No silos configured yet</h3>
+        <h3 className="text-lg font-semibold mb-2">No content silos found</h3>
         <p className="text-sm text-muted-foreground max-w-md">
-          Silo health scores will appear once your site structure is analyzed.
+          Make sure your pages are synced and classified, then your service pages will appear here as separate silos with depth analysis.
         </p>
       </div>
     );

--- a/components/screens/SiteIntelligencePanel.tsx
+++ b/components/screens/SiteIntelligencePanel.tsx
@@ -430,14 +430,15 @@ export default function SiteIntelligencePanel({ siteId }: SiteIntelligencePanelP
       {!intelligenceData && !isGenerating && !error && (
         <div className="flex flex-col items-center justify-center min-h-[30vh] text-slate-400 gap-3">
           <span className="text-4xl">🧠</span>
+          <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-200">No analysis yet</h3>
           <p className="text-sm text-center max-w-md">
-            No intelligence data yet. Click &quot;Generate SEO Plan&quot; to analyze your site with Claude AI.
+            Click &quot;Generate SEO Plan&quot; to get your prioritized action list — Claude AI will analyze your full site architecture.
           </p>
           <button
             onClick={handleGenerate}
             className="mt-2 inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold rounded-lg bg-slate-900 hover:bg-slate-700 text-white border border-slate-800 transition-colors"
           >
-            Generate SEO Plan
+            Generate SEO Plan &rarr;
           </button>
         </div>
       )}

--- a/components/screens/TeamAuthorsTab.tsx
+++ b/components/screens/TeamAuthorsTab.tsx
@@ -726,16 +726,16 @@ export default function TeamAuthorsTab() {
             </svg>
           </div>
           <div>
-            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-200">No authors yet</h3>
+            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-200">No team members added yet</h3>
             <p className="text-sm text-slate-500 mt-1 max-w-md">
-              Add your first author to start building E-E-A-T entity signals for your content.
+              Add your first author to start attributing content and building E-E-A-T signals.
             </p>
           </div>
           <button
             onClick={() => { setEditingAuthor(null); setFormOpen(true); }}
             className="px-5 py-2.5 text-sm font-semibold rounded-xl bg-blue-600 hover:bg-blue-700 text-white transition-colors"
           >
-            Add Author
+            Add Author &rarr;
           </button>
         </div>
       ) : (


### PR DESCRIPTION
## UX improvements for non-technical users

### Onboarding checklist on Dashboard Home
- Progress bar tracking 5 setup steps (sync pages, add services, connect GSC, run analysis)
- Clickable steps link directly to the right tab
- Hidden once all steps complete

### Better empty states
- Intelligence/SEO Plan: clear CTA when no analysis run yet
- Content Plan: improved empty state messaging
- Team & Authors: 'Add Author' CTA when no authors
- Content Depth: explains what to do when no silos found

### Clearer nav labels + subtitles
- 'Intelligence' → 'SEO Plan' with subtitle 'Prioritized action list'
- 'Depth Engine' → 'Content Depth' with subtitle 'Find topic gaps'
- All nav items now show description below label
- TAB_REDIRECTS checked — no conflicts

### Site selector status indicators
- Green dot = pages synced + GSC connected
- Yellow dot = pages synced, no GSC
- Red dot = no pages synced
- Site name bold, URL muted below